### PR TITLE
Update how we send emails to courts and access

### DIFF
--- a/docassemble/MAVirtualCourt/data/questions/send_email_test.yml
+++ b/docassemble/MAVirtualCourt/data/questions/send_email_test.yml
@@ -1,7 +1,3 @@
-metadata:
-  title: Default playground interview
-  short title: Test
-  comment: This is a learning tool.  Feel free to write over it.
 ---
 include:
   - basic-questions.yml

--- a/docassemble/MAVirtualCourt/data/questions/send_email_test.yml
+++ b/docassemble/MAVirtualCourt/data/questions/send_email_test.yml
@@ -55,7 +55,6 @@ attachment:
 question: |
   Interview 0 result
 subquestion: |
-  ${ url_of("playground")}
   We have just compiled and submitted your attachment [here](${ interveiw_0_attachment.url_for() }) 
   Your submission id is **${submission_id_0}**.
   
@@ -106,16 +105,16 @@ subquestion: |
 
     You should see the following:
 
-    ```
     Dear ${ fake_court_name }:
 
     You are receiving 1 file(s) from ${ users[0].name }: 
 
     interveiw_1_attachment.pdf
-    ```
 
     At the bottom, you should also see a link.
-    If you click on the link, it should take you to a page to view submissions/
+    If you click on the link, it should take you to a page to view submissions.
+
+    Please note, this link will only work properly if this package is installed on the server
   % else:
     According to our records, the email did not send successfully.
     
@@ -169,7 +168,6 @@ subquestion: |
 
     You should see the following:
 
-    ```
     Dear ${ fake_court_name }:
 
     You are receiving 2 file(s) from ${ users[0].name }: 
@@ -177,7 +175,6 @@ subquestion: |
     interveiw_1_attachment.pdf
     
     interveiw_2_attachment.pdf
-    ```
 
     At the bottom, you should also see a link.
     If you click on the link, it should take you to a page to view submissions/
@@ -189,6 +186,15 @@ subquestion: |
 
   You can review your subquestion [here](${ url_for_submission(id=submission_id_1) })
 continue button field: to_interview_3
+---
+progress: 100
+event: complete_test
+question: |
+  That's it!
+subquestion: |
+  If both emails sent successfully (matching the format exactly), they the tests have succeeded.
+
+  However, if any of the emails did **not** send correctly, please make note of that.
 ---
 mandatory: True
 code: |
@@ -224,3 +230,4 @@ code: |
   result_2 = send_attachments(name=name, court_name=fake_court_name, court_emails=court_emails, files=files, submission_id=submission_id_2)
 
   to_interview_3
+  complete_test

--- a/docassemble/MAVirtualCourt/data/questions/send_email_test.yml
+++ b/docassemble/MAVirtualCourt/data/questions/send_email_test.yml
@@ -25,11 +25,51 @@ subquestion: |
   
   We will set this fake court as your preferred court. In an actual interview, we would ask you for your preffered court.
 
-  Make sure that you have access to the email you have provided.
+  Make sure that you have access to the email you have provided. 
+  For best testing, please provide an email that is not the one you are currently using to sign into this account.
 fields:
   - Fake court name: fake_court_name
   - Fake court email: fake_court_email
     datatype: email
+---
+question: |
+  Interview 0
+subquestion: |
+  This email does **not** test sending emails.
+  Rather, it tests whether or not we are able to save metadata and allow the appropriate users access.
+
+  This test will work best if you have installed the package.
+  If you have not, the links provided will **not** work. 
+
+  Do you want to run this test?
+yesno: wants_submission_test
+---
+attachment:
+  variable name: interveiw_0_attachment
+  filename: interveiw_0_attachment
+  persistent: True
+  private: True
+  content: |
+    This is interview 0 for the court ${ fake_court_name }
+---
+question: |
+  Interview 0 result
+subquestion: |
+  ${ url_of("playground")}
+  We have just compiled and submitted your attachment [here](${ interveiw_0_attachment.url_for() }) 
+  Your submission id is **${submission_id_0}**.
+  
+  You can access your submission using the following link:
+  **[${ url_for_submission(id=submission_id_0)}](${ url_for_submission(id=submission_id_0)})**.
+  
+  If you click on the link, you should see the following page:
+
+  #### Expected content
+
+  You are authorized to see submission ${ submission_id_0 }
+
+  * interveiw_0_attachment: [${ interveiw_0_attachment.url_for() }](${ interveiw_0_attachment.url_for() }).
+field: finished_interview_0
 ---
 question: |
   Interview 1
@@ -156,8 +196,13 @@ code: |
   court_emails[fake_court_name] = fake_court_email
   emails_to_courts = reverse_dictionary(court_emails)
 
+  if wants_submission_test:
+    files = [interveiw_0_attachment.pdf]
+    interveiw_0_attachment
+    submission_id_0 = new_entry(court_emails=court_emails, court_name=fake_court_name, name="Dummy User", files=files)
+    finished_interview_0
+
   saw_interview_1
-  users[0].name
   interveiw_1_attachment
   send_interview_1
 

--- a/docassemble/MAVirtualCourt/data/questions/send_email_test.yml
+++ b/docassemble/MAVirtualCourt/data/questions/send_email_test.yml
@@ -212,22 +212,26 @@ code: |
   interveiw_1_attachment
   send_interview_1
 
-  files = [interveiw_1_attachment.pdf]
   name = str(users[0].name)
   
-  submission_id_1 = new_entry(court_emails=court_emails, court_name=fake_court_name, name=name, files=files)
-  result_1 = send_attachments(name=name, court_name=fake_court_name, court_emails=court_emails, files=files, submission_id=submission_id_1)
-  
+  result_1
+
   to_interview_2
   saw_interview_2
   interview_2_textbox
   interveiw_2_attachment
   send_interview_2
-
-  files = [interveiw_1_attachment.pdf, interveiw_2_attachment.pdf]
-
-  submission_id_2 = new_entry(court_emails=court_emails, court_name=fake_court_name, name=name, files=files)
-  result_2 = send_attachments(name=name, court_name=fake_court_name, court_emails=court_emails, files=files, submission_id=submission_id_2)
-
+  result_2
+  
   to_interview_3
   complete_test
+---
+code: |
+  files_1 = [interveiw_1_attachment.pdf]
+  submission_id_1 = new_entry(court_emails=court_emails, court_name=fake_court_name, name=name, files=files_1)
+  result_1 = send_attachments(name=name, court_name=fake_court_name, court_emails=court_emails, files=files_1, submission_id=submission_id_1)
+---
+code: |
+  files_2 = [interveiw_1_attachment.pdf, interveiw_2_attachment.pdf]
+  submission_id_2 = new_entry(court_emails=court_emails, court_name=fake_court_name, name=name, files=files_2)
+  result_2 = send_attachments(name=name, court_name=fake_court_name, court_emails=court_emails, files=files_2, submission_id=submission_id_2)

--- a/docassemble/MAVirtualCourt/data/questions/send_email_test.yml
+++ b/docassemble/MAVirtualCourt/data/questions/send_email_test.yml
@@ -10,45 +10,172 @@ modules:
   - .upload
 ---
 question: |
-  Here is your document, ${ users[0] }.
+  Testing sending emails and viewing submissions
 subquestion: |
-  In order ${ quest }, you will need this.
-attachments:
-  - name: Information Sheet
-    filename: info sheet
-    variable name: info_sheet
-    persistent: True
-    private: True
-    content: |
-      Your name is ${ users[0] }.
-      Your quest is ${ quest }.
-field: seen_attachment
----
-question: |  
-  Hi ${ result }
-subquestion: |
-  You can review your submission [here](${ url_for_submission(id=submission_id) }). 
-field: seen_hi
+  The goal of the interview is to test and verify sending completed interviews, as well as verifying that the submissions can be only viewed by authorized individuals.
+  
+  You will fill out a few extremely short interviews, which we will then send to an email you have provided us.
+continue button field: saw_intro
 ---
 question: |
-  What is your quest?
+  Where should we send your emails
+subquestion: |
+  In an actual interview, we would send the email to a court. 
+  However, to prevent unnecessary spam, please provide a name and court that we will treat as an actual court.
+  
+  We will set this fake court as your preferred court. In an actual interview, we would ask you for your preffered court.
+
+  Make sure that you have access to the email you have provided.
 fields:
-  - Your quest: quest
-    hint: to find the Loch Ness Monster
+  - Fake court name: fake_court_name
+  - Fake court email: fake_court_email
+    datatype: email
+---
+question: |
+  Interview 1
+subquestion: |
+  In this first interview, we will just ask you your name. 
+continue button field: saw_interview_1
+---
+attachment:
+  variable name: interveiw_1_attachment
+  filename: interveiw_1_attachment
+  persistent: True
+  private: True
+  content: |
+    This is interview 1.
+    Your name is ${ users[0].name }
+---
+question: |
+  Sending interview 1
+subquestion: |
+  We have now assembled the first interview.
+
+  ${ interveiw_1_attachment }
+
+  Please press 'continue' to send this email. 
+  We will then ask you to verify that you have received the email.
+continue button field: send_interview_1
+---
+question: |
+  Results of sending interview 1
+subquestion: |
+  % if result_1:
+    According to our records, the email has been sent successfully!
+    Please check the email ${ fake_court_email }.
+
+    You should see the following:
+
+    ```
+    Dear ${ fake_court_name }:
+
+    You are receiving 1 file(s) from ${ users[0].name }: 
+
+    interveiw_1_attachment.pdf
+    ```
+
+    At the bottom, you should also see a link.
+    If you click on the link, it should take you to a page to view submissions/
+  % else:
+    According to our records, the email did not send successfully.
+    
+    If you have confirmed that ${ fake_court_email } is a real email, then there is probably a problem with the code.
+  % endif
+
+  You can review your subquestion [here](${ url_for_submission(id=submission_id_1) })
+continue button field: to_interview_2
+---
+question: |
+  Interview 2
+subquestion: |
+  Now, let's complete another interview so that we can test sending multiple attachments.
+continue button field: saw_interview_2
+---
+question: |
+  Sample question
+subquestion: |
+  Fill in whatever you want here.
+fields:
+  - Textbox: interview_2_textbox
+    input type: area
+---
+attachment:
+  variable name: interveiw_2_attachment
+  filename: interveiw_2_attachment
+  persistent: True
+  private: True
+  content: |
+    This is interview 2.
+    Your name is ${ users[0].name }.\
+
+    You said ${ interview_2_textbox}
+---
+question: |
+  Sending interview 2
+subquestion: |
+  We have now assembled the second interview.
+
+  ${ interveiw_2_attachment }
+
+  We will now send you an email containing both interviews.
+continue button field: send_interview_2
+---
+question: |
+  Results of sending interview 2
+subquestion: |
+  % if result_2:
+    According to our records, the email has been sent successfully!
+    Please check the email ${ fake_court_email }.
+
+    You should see the following:
+
+    ```
+    Dear ${ fake_court_name }:
+
+    You are receiving 2 file(s) from ${ users[0].name }: 
+
+    interveiw_1_attachment.pdf
+    
+    interveiw_2_attachment.pdf
+    ```
+
+    At the bottom, you should also see a link.
+    If you click on the link, it should take you to a page to view submissions/
+  % else:
+    According to our records, the email did not send successfully.
+    
+    If you have confirmed that ${ fake_court_email } is a real email, then there is probably a problem with the code.
+  % endif
+
+  You can review your subquestion [here](${ url_for_submission(id=submission_id_1) })
+continue button field: to_interview_3
 ---
 mandatory: True
 code: |
-  court_emails["test court"] = "kgarner"
+  saw_intro
+  court_emails[fake_court_name] = fake_court_email
   emails_to_courts = reverse_dictionary(court_emails)
-  seen_attachment
-  
-  files = [info_sheet.pdf]
-  court_name = "test court"
+
+  saw_interview_1
+  users[0].name
+  interveiw_1_attachment
+  send_interview_1
+
+  files = [interveiw_1_attachment.pdf]
   name = str(users[0].name)
   
-  submission_id = new_entry(court_emails=court_emails, court_name=court_name, name=name, files=files)
-  result = send_attachments(name=name, court_name=court_name, court_emails=court_emails, files=files, submission_id=submission_id)
+  submission_id_1 = new_entry(court_emails=court_emails, court_name=fake_court_name, name=name, files=files)
+  result_1 = send_attachments(name=name, court_name=fake_court_name, court_emails=court_emails, files=files, submission_id=submission_id_1)
   
-  # how to make a file from attributes in the table
-  # file = DAFile(number=39, filename="info sheet.pdf", mimetype="application/pdf")
-  seen_hi
+  to_interview_2
+  saw_interview_2
+  interview_2_textbox
+  interveiw_2_attachment
+  send_interview_2
+
+  files = [interveiw_1_attachment.pdf, interveiw_2_attachment.pdf]
+
+  submission_id_2 = new_entry(court_emails=court_emails, court_name=fake_court_name, name=name, files=files)
+  result_2 = send_attachments(name=name, court_name=fake_court_name, court_emails=court_emails, files=files, submission_id=submission_id_2)
+
+  to_interview_3

--- a/docassemble/MAVirtualCourt/data/questions/send_email_test.yml
+++ b/docassemble/MAVirtualCourt/data/questions/send_email_test.yml
@@ -1,0 +1,54 @@
+metadata:
+  title: Default playground interview
+  short title: Test
+  comment: This is a learning tool.  Feel free to write over it.
+---
+include:
+  - basic-questions.yml
+---
+modules:
+  - .upload
+---
+question: |
+  Here is your document, ${ users[0] }.
+subquestion: |
+  In order ${ quest }, you will need this.
+attachments:
+  - name: Information Sheet
+    filename: info sheet
+    variable name: info_sheet
+    persistent: True
+    private: True
+    content: |
+      Your name is ${ users[0] }.
+      Your quest is ${ quest }.
+field: seen_attachment
+---
+question: |  
+  Hi ${ result }
+subquestion: |
+  You can review your submission [here](${ url_for_submission(id=submission_id) }). 
+field: seen_hi
+---
+question: |
+  What is your quest?
+fields:
+  - Your quest: quest
+    hint: to find the Loch Ness Monster
+---
+mandatory: True
+code: |
+  court_emails["test court"] = "kgarner"
+  emails_to_courts = reverse_dictionary(court_emails)
+  seen_attachment
+  
+  files = [info_sheet.pdf]
+  court_name = "test court"
+  name = str(users[0].name)
+  
+  submission_id = new_entry(court_emails=court_emails, court_name=court_name, name=name, files=files)
+  result = send_attachments(name=name, court_name=court_name, court_emails=court_emails, files=files, submission_id=submission_id)
+  
+  # how to make a file from attributes in the table
+  # file = DAFile(number=39, filename="info sheet.pdf", mimetype="application/pdf")
+  seen_hi

--- a/docassemble/MAVirtualCourt/data/questions/submission.yml
+++ b/docassemble/MAVirtualCourt/data/questions/submission.yml
@@ -1,14 +1,19 @@
+include:
+  - basic-questions.yml
+---
 modules:
   - .upload
 ---
 mandatory: True
 code: |
-  court_emails = { "test court": "kgarner@mit.edu" }
+  court_emails["test court"] = "kgarner@mit.edu"
+  
+  emails_to_courts = reverse_dictionary(court_emails)
     
   if "id" in url_args:
     id = url_args["id"]
     
-    if can_access_submission(submission_id=id, court_emails=court_emails):
+    if can_access_submission(submission_id=id, emails_to_courts=emails_to_courts):
       authorized
     else:
       if user_logged_in():
@@ -16,13 +21,13 @@ code: |
       else:
         not_authorized_login
   else:
-    [submissions, field] = get_accessible_submissions(court_emails=court_emails)
+    [submissions, field] = get_accessible_submissions(emails_to_courts=emails_to_courts)
     no_submission
 ---
 event: view_submission
 code: |
   id = action_argument("id");
-  if can_access_submission(submission_id=id, court_emails=court_emails):
+  if can_access_submission(submission_id=id, emails_to_courts=emails_to_courts):
     authorized
 ---
 event: authorized

--- a/docassemble/MAVirtualCourt/data/questions/submission.yml
+++ b/docassemble/MAVirtualCourt/data/questions/submission.yml
@@ -5,9 +5,7 @@ modules:
   - .upload
 ---
 mandatory: True
-code: |
-  court_emails["test court"] = "kgarner@mit.edu"
-  
+code: |  
   emails_to_courts = reverse_dictionary(court_emails)
     
   if "id" in url_args:

--- a/docassemble/MAVirtualCourt/data/questions/submission.yml
+++ b/docassemble/MAVirtualCourt/data/questions/submission.yml
@@ -34,7 +34,7 @@ event: authorized
 question: |
   You are authorized to see submission ${ id }
 subquestion: |
-  % for file in get_files(submission_id=id, authorized=True):
+  % for file in get_files(submission_id=id):
   * ${ file.filename }: [${file.url_for()}](${file.url_for()})
   % endfor
 ---

--- a/docassemble/MAVirtualCourt/upload.py
+++ b/docassemble/MAVirtualCourt/upload.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from docassemble.base.core import DAFile
-from docassemble.base.functions import defined, get_user_info, interview_url
+from docassemble.base.functions import defined, get_user_info, interview_url, quantity_noun
 from docassemble.base.util import get_config, send_email, user_info
 from psycopg2 import connect
 from textwrap import dedent
@@ -259,7 +259,7 @@ def send_attachments(name="", court_name="", court_emails=dict(), files=[], subm
   court_email = court_emails[court_name]
 
   filenames = [file.filename for file in attachments]
-  filenames_str = "\n".join(filenames)
+  filenames_str = "\n    ".join(filenames)
   submission_url = url_for_submission(id=submission_id)
 
   if len(attachments) != len(files):
@@ -267,7 +267,7 @@ def send_attachments(name="", court_name="", court_emails=dict(), files=[], subm
       body = dedent(f"""
       Dear {court_name}:
 
-      {name} has submitted {len(files)} online. However, these file(s) have sensitive information, and will not be sent over email.
+      {name} has submitted {len(files)} file(s) online. However, these file(s) have sensitive information, and will not be sent over email.
       
       Please access these forms with the following submission id: {submission_url}.
       """)
@@ -277,10 +277,10 @@ def send_attachments(name="", court_name="", court_emails=dict(), files=[], subm
       body = dedent(f"""
       Dear {court_name}:
       
-      You are receiving {len(attachments)} files from {name}:
+      You are receiving {quantity_noun(len(attachments), "file")} from {name}:
       {filenames_str}
 
-      However, there are also {len(files) - len(attachments)} forms which are sensitive that will not be sent over email.
+      However, there are also {quantity_noun(len(files) - len(attachments), "form")} which are sensitive that will not be sent over email.
 
       Please access these forms with the following submission id: {submission_url}.
       """)
@@ -288,7 +288,7 @@ def send_attachments(name="", court_name="", court_emails=dict(), files=[], subm
     body = dedent(f"""
     Dear {court_name}:
 
-    You are receiving {len(attachments)} files from {name}:
+    You are receiving {quantity_noun(len(attachments), "file")} from {name}:
     {filenames_str}
 
     The reference ID for these forms is {submission_url}.


### PR DESCRIPTION
Changes:

1. Added a demo interview `send_email_test.yml` to demonstrate emails working
2. Modify `uploads.py` to take in email <-> name dictionaries when reasonable, and update `submission.yml` appropriately
3. Restrict access in `uploads.py` to only the court who received it. This was missing before.
4. In `uploads.py`, grant access to files in the `can_access_submission`, not `get_files`

Things to review:

- `uploads.py`: In particular, we should review that a user is **only** granted access if they have a valid email. In the future, we should probably have a review process for this.
- `submission.yml`: This is the interview that would serve as the base for people to access all submissions. We should make sure that it only shows data that the user (files they submitted)/court (files submitted to the court) should see 

Improvements:

- `send_attachments()` in `uploads.py`: currently, this just uses a plain-text body for the email. It also does not give a good description. We should make this more useful for the courts.

A note: the `url_for_submission()` method only works properly if the package is installed. I couldn't figure out a good way for it to to figure out the location of the `submission.yml` file in the playground of the current user.