### PR TITLE
github issue 378 semi-urgent, remove defendant will see addresses if …

### DIFF
--- a/docassemble/MAVirtualCourt/data/questions/209A_Page_1.yml
+++ b/docassemble/MAVirtualCourt/data/questions/209A_Page_1.yml
@@ -716,12 +716,14 @@ fields:
   - no label: related_as_couple
     datatype: checkboxes
     choices:
-      - 'I have been dating ${ other_parties.familiar() }.': dating
+      - 'I am dating ${ other_parties.familiar() }.': dating
       - 'We **used** to date.': dated
       - 'We are engaged.': engaged
       - 'We **used** to be engaged.': past_engaged
     none of the above: False
     required: False
+  - note: |
+      Were you ever married to ${other_parties.familiar()}?
   - no label: relationship_to_defendant_married
     datatype: checkboxes
     choices:

--- a/docassemble/MAVirtualCourt/data/questions/209A_Page_1.yml
+++ b/docassemble/MAVirtualCourt/data/questions/209A_Page_1.yml
@@ -722,7 +722,7 @@ fields:
       - 'We **used** to be engaged.': past_engaged
     none of the above: False
     required: False
-  - 'Were you ever married to ${ other_parties.familiar() }?': relationship_to_defendant_married
+  - no label: relationship_to_defendant_married
     datatype: checkboxes
     choices:
       - 'We are married now.': now

--- a/docassemble/MAVirtualCourt/data/questions/209A_affidavit.yml
+++ b/docassemble/MAVirtualCourt/data/questions/209A_affidavit.yml
@@ -79,7 +79,7 @@ terms:
 id: 209 Affidavit what to include
 continue button field: complaint_209A_Affidavit_intro_2
 question: |
-  Explaining to the judge why you need a restraining order  
+  Explain to the judge why you need a restraining order  
 subquestion: |
   In your affidavit, do your best to describe the times that ${other_parties.familiar()} abused you. What did ${other_parties.familiar()} say and do?
   
@@ -90,12 +90,12 @@ subquestion: |
   Include information about injuries, medical treatment or dental treatment you needed, destruction of property, or sometimes, the police.
   % if plaintiff_has_minor_children:
   
-  * If you have children write about:
+  * The judge should also know about:
   
       * Times ${other_parties.familiar()} abused your child,
       * Where your ${children.as_noun()} ${children.did_verb('was')} when ${other_parties.familiar()} was abusing you,
-      * Times your child witnessed ${other_parties.familiar()} abusing you, and
-      * How the abuse affected your child.
+      * Times your ${children.as_noun()} witnessed ${other_parties.familiar()} abusing you, and
+      * How the abuse affected your ${children.as_noun()}.
   % endif
 ---
 id: 209A Affidavit you can do it
@@ -109,9 +109,8 @@ subquestion: |
 
   Finally, as you write your affidavit, keep in mind that when you sign your name at the end of this guide, you are declaring, “{under penalty of perjury}” that your answers to all these questions are {true to the best of your knowledge}.
 
-  Start with the most recent abuse first.
-
-  Then tell the judge about other serious incidents, if there are any.   
+  1. Start with the most recent abuse first.  
+  2. Then tell the judge about other serious incidents, if there are any.   
 help:
   label: What should I talk about?
   heading: Is this all?
@@ -125,14 +124,15 @@ help:
     This is your chance to explain why you need help.
 terms:
   - under penalty of perjury: |
-      means you swear that what you write is true, as far as you know.
+      means you swear that what you write is true, as far as you know.  
          
-      Swearing "under penalty of perjury" means the court can punish you if what you write is not true to the best of your knowledge.
+      Swearing "under penalty of perjury" means the court can punish you if what you write is not true to the best of your knowledge.  
       
-      The court cannot punish you if you write about things you saw, heard, or felt.
+      The court cannot punish you if you write about things you saw, heard, or felt.  
       The court cannot punish you if you have good reason to believe that what you write is true.
   - true to the best of your knowledge: |
-      Something is true "to the best of your knowledge" if you were there and saw, heard, or felt it. Something is true to the best of your knowledge if you have good reason to believe it is true.
+      Something is true "to the best of your knowledge" if you were there and saw, heard, or felt it.  
+      Something is true to the best of your knowledge if you have good reason to believe it is true.
 ---
 id: complaint_209A_Affidavit
 code: |
@@ -335,7 +335,7 @@ fields:
   - no label: incidents_of_abuse[i].description
     input type: area
     default: |
-      On or about ${ incidents_of_abuse[i].date }, ${ incidents_of_abuse[i].time_of_day } at ${ incidents_of_abuse[i].location } .
+      On or about ${ incidents_of_abuse[i].date }, ${ incidents_of_abuse[i].time_of_day } ${ incidents_of_abuse[i].location }, 
 help:
   label: How descriptive should I be?
   heading: How descriptive should I be?
@@ -523,45 +523,49 @@ fields:
     input type: area
     required: False
 ---
-id: 209A Affidavit Summary
+id: 209A Incident Summary
 question: |
-  Affidavit Summary
-subquestion: |
-  The affidavit must be in your own words.
-  
-  This is what you have told me about this incident, so far. 
-  
-  If you need to add or change anything, you can edit your affidavit in the box below:
+  % if started:
+  The most recent abuse
+  % else:
+  The ${ordinal(i)} incident you described
+  % endif
+subquestion: | 
+  This is what you have told me about this incident, so far.  
+  If you need to add or change anything, you can edit it in the box below:
 fields:
   - no label: incidents_of_abuse[i].summary
     input type: area
+    rows: 10
     default: |
       ${ incidents_of_abuse[i].description + space("incidents_of_abuse[" + str(i) + "].feelings", prefix=' Because of what happened, I felt ') }
 ---
 id: there is another abuse incident
 question: |
   Can you describe another time ${other_parties.familiar()} abused you?
-subquestion: |
-  % if plaintiff_has_minor_children:
-  You said you have at least 1 child under 18. 
+# subquestion: |
+#   % if plaintiff_has_minor_children:
+#   You said you have at least 1 child under 18. 
   
-  Even if ${other_parties.familiar()} did not injure your ${children.as_noun()}, it could be important to include:
+#   Even if ${other_parties.familiar()} did not injure your ${children.as_noun()}, it could be important to include:
   
-  * Where your child was during the incident.
-  * If your ${children.as_noun()} witnessed anything. And
-  * How it affected your ${children.as_noun()}. 
-  % endif
+#   * Where your child was during the incident.
+#   * If your ${children.as_noun()} witnessed anything. And
+#   * How it affected your ${children.as_noun()}. 
+#   % endif
 yesno: incidents_of_abuse.there_is_another
 ---
 id: saw incidents of abuse
 question: |
-  This is what will go into your Affidavit: 
+  This is your Affidavit 
 subquestion: |
-  The affidavit will start with this text:
+  These are your words. Edit this statement in any way you need so that it says exactly what you need to tell the judge.  
+  Once you are satisfied you have told the truth, as far you know, go on to the next set of questions.
+# The affidavit will start with this text:
 
-  > The following is a brief summary of the events 
-  > and does not attempt to capture all the detail 
-  > of the abuse  
+# > The following is a brief summary of the events 
+# > and does not attempt to capture all the detail 
+# > of the abuse  
 fields:
   - no label: affidavit_body
     input type: area

--- a/docassemble/MAVirtualCourt/data/questions/209A_complaint_for_protection_from_abuse_probation.yml
+++ b/docassemble/MAVirtualCourt/data/questions/209A_complaint_for_protection_from_abuse_probation.yml
@@ -460,7 +460,7 @@ subquestion: |
   % if i == 0:
   Tell us about your oldest child first.
   % else:
-  You have already told us
+  You told us
   about ${comma_and_list([child.familiar() for child in children.complete_elements()])}. 
   Tell us about your ${ordinal(i)} child. 
   % endif
@@ -537,11 +537,11 @@ comment: |
   Changed code to list only first names of children in question id: children user is parent of, but then choices for children_of_both became their full names in this question instead of only first names - even after I added '.familiar()' to the end.
 id: custody_children
 question: |
-  Do you need the judge to grant you custody of the children?
+  Do you need the judge to give you custody of the ${children.as_noun()}?
 fields:
-  - I need the judge to give me custody of ${children_of_both.familiar_or()}: requests_custody
+  - I need custody of the ${children.as_noun()} I have in common with ${other_parties.familiar()}.: requests_custody
     datatype: yesnoradio
-  - Which children do you want custody of?: wants_custody_of
+  - Which children do you need custody of?: wants_custody_of
     show if: requests_custody
     datatype: object_checkboxes
     choices: |
@@ -558,9 +558,9 @@ id: no_contact_children
 question: |
   Do you need the judge to order ${other_parties.familiar()} not to contact the children?
 fields:
-  - I need the judge to order no contact for ${comma_and_list([child.familiar() for child in children + children_cares_for], and_string=word("or"))}: request_no_contact
+  - I need the judge to order 'No contact.': request_no_contact
     datatype: yesnoradio
-  - Which child?: wants_no_contact_for
+  - Which children?: wants_no_contact_for
     datatype: object_checkboxes
     show if: request_no_contact
     choices: |

--- a/docassemble/MAVirtualCourt/data/questions/209A_complaint_for_protection_from_abuse_probation.yml
+++ b/docassemble/MAVirtualCourt/data/questions/209A_complaint_for_protection_from_abuse_probation.yml
@@ -479,6 +479,8 @@ fields:
   - Last Name: children[i].name.last
   - Suffix: children[i].name.suffix
     required: False
+    code: |
+      name_suffix()
   - Birthdate: children[i].birthdate
     datatype: date
     min: ${ today().minus(years=18) }

--- a/docassemble/MAVirtualCourt/data/questions/motion-for-impoundment.yml
+++ b/docassemble/MAVirtualCourt/data/questions/motion-for-impoundment.yml
@@ -106,17 +106,22 @@ code: |
 ---
 id: impound other
 question: |
-  Keeping information private (impoundment)
+  Keeping information private - Asking the court to impound
 subquestion: |
-  Unless you ask the court, the forms you file (other than the confidential information form)
-  will become a public record.
+  The only information the court keeps private automatically, is your 
+  % if plaintiff_has_minor_children:
+  ${ children.as_noun()}'s addresses and 
+  % endif
+  your contact information, that goes on the Plaintiff Confidential Information form: your address, phone numbers, email and the best way to reach you. 
 
-  You can ask the court to keep your form private.
+  The rest of the forms you file are public record.  
+  
+  You can ask the court to impound your other forms to keep other information in your forms private. You will need to explain why it is critical to your safety to keep this information private.
 fields:
   - Is there any information on this form that you need to keep private?: impound_case_record_information
     datatype: yesnoradio
   - note: |
-      Explain what you want kept private below
+      Explain what you need the court to keep private below:
     show if: impound_case_record_information      
   - no label: case_record_information_to_be_impounded
     show if: impound_case_record_information
@@ -125,7 +130,7 @@ fields:
 Comment: |
   At this point we already know if plaintiff has asked court to order defendant to stay away from any addresses. So this question should be more intelligent. 
   Pursuant to G.L. c. 209A, § 8 or G.L. c. 258E, § 10 - not needed.
-id: impoud contact info  
+id: impound contact info
 question: |
   Keep private -  information about how to contact you
 subquestion: |
@@ -142,7 +147,7 @@ subquestion: |
   % endif,  and
   * telephone numbers.
   
-  **If you asked the court to order ${other_parties.familiar()} to keep away from any address, the court will not impound that address.**
+  The Court can keep your address from ${other_parties.familiar()} even if the judge orders ${other_parties.familiar()} to stay away from that address. Your restraining order will order ${other_parties.familiar()} to stay away from your address, "wherever that may be."
 
   Do you need to keep your addresses and phone numbers private?
 yesno: impound_personal_information
@@ -157,11 +162,11 @@ help:
     ${ other_parties.familiar() }’s lawyer and 
     * will be available to you, your lawyer, people you give the court permission to show, and to certain persons who may need this information so they can do their job. These are prosecutors, law enforcement officers, victim-witness advocates, sexual assault counselors and domestic violence counselors.
     
-    But if you asked the court to order  ${ other_parties.familiar() } to stay away from your home, work or school, ${ other_parties.familiar() } and ${ other_parties.familiar() }'s lawyer the order will show the address ${ other_parties.familiar() } must stay away from.
+    If you asked the court to order  ${ other_parties.familiar() } to stay away from your home, work or school, the order will say ${ other_parties.familiar() } must stay away from your home, work or school, "whereever that may be."
     
-    If you have good reasons why the court should not share this information with people who normally see the information to do their jobs, you may ask the judge to issue an Order of Impoundment. 
+    If you need the court not to share this information with people who normally see the information to do their jobs, you may ask the judge to issue an Order of Impoundment. 
     
-    Normally, everything in your complaint **except** your address, phone and email information is public. You may also ask the judge to impound this other information from the public. But you need to explain to the judge why your safety depends on impounding this other information. Your need for privacy is not a good enough reason for a judge to decide to impound court records. 
+    Normally, everything in your complaint **except** your address, phone and email information is public. You may ask the judge to impound this other information from the public also. But you need to explain to the judge why your safety depends on impounding this other information. Your need for privacy is not a good enough reason for a judge to decide to impound court records. 
     
     If you ask the judge to impound information with **no notice** to ${ other_parties.familiar()} or any other interested persons, you must explain why giving notice would put you at risk of immediate harm that you would not be able to recover from.
 ---

--- a/docassemble/MAVirtualCourt/data/questions/plaintiff-confidential.yml
+++ b/docassemble/MAVirtualCourt/data/questions/plaintiff-confidential.yml
@@ -215,8 +215,11 @@ id: your address
 question: |
   Your address
 subquestion: |
-  You will have a chance to request this address to be kept
-  private later.
+  % if order_impound_plaintiff_address_residential_yes:
+  You already asked the court to keep your address off any court orders. But the court needs your address so they can reach you about your case. 
+  % else:
+  The court keeps your address on the Plaintiff Confidential Information form, separate from the rest of your file. 
+  % endif 
 fields:
   - Street address: users[0].address.address
     address autocomplete: True


### PR DESCRIPTION
changed screen layout for Were you ever a 'couple'
fixed dating language for relationship
removed label for marriage relationship
de-emphasize the importance of including children in affidavit - github issue or slack - can't find right now
added more space in explanation of" pain of penalty and perjury" and "the best of your knowledge"
changed period after date and location of abuse to a comma
changed incident summary to reflect incident rather than affidavit
increased space for describing incident
deleted text in Affidavit summary that refers to introductory sentence which we have now moved to concluding sentence
more readability edits in page 2
draft1 of  most important impoundment language in motion of impoundment and plaintiff confidential information forms - this still needs work, but at least it's accurate
**Notes to fix still**
1. Plaintiff home address does not appear on final PDF, this may be something I did in previous commit that has already been merged. If home address is impounded it still needs to appear on PDF - Note from[ Kate in GoogleDoc](https://docs.google.com/document/d/1Xwq2FZ5a0jyiTtWK5VYzXUno5_y_dSiZC-E6mmXmn10/edit?usp=sharing
)
2. Addendum for No contact with children appeared, even though I said defendant could have contact
3. Checkbox to impound addresses on motion for impoundment form was not checked despite boxes in page 1 relief requesting that all 3 addresses be impounded.





