### PR TITLE
Statement of damages on two screens and currency datatype added

### DIFF
--- a/docassemble/MAVirtualCourt/data/questions/Civil_Action_Cover_Sheet.yml
+++ b/docassemble/MAVirtualCourt/data/questions/Civil_Action_Cover_Sheet.yml
@@ -4,10 +4,9 @@ code: |
   if not defined("interview_metadata['Civil_Action_Cover_Sheet0026']"):
     interview_metadata.initializeObject('Civil_Action_Cover_Sheet0026')
   interview_metadata['Civil_Action_Cover_Sheet0026'].update({
-    'title': 'Civil Action Cover Sheet New Branch',
+    'title': 'Civil Action Cover Sheet',
     'short title': 'Civil Action Cover Sheet',
-    'description': 'A civil cover sheet must be filed with each complaint in Superior Court.',
-#Why is the description not pulling the updated description into the interview? How do we make it do this?
+    'description': 'Placeholder text',
     'original_form': 'https://www.mass.gov/files/documents/2016/08/tf/civil-action-cover-sheet-specific-counties.pdf',
     'allowed courts': [
       'Superior Court',
@@ -218,12 +217,17 @@ code: |
 ---
 continue button field: Contract_claims
 question: |
-  Contract claims
+  Does this action involve contract claims?
 subquestion: |
-  Describe the contract claims and provide the total dollar value of the claims.
+  If this civil action involves contract claims, provide a description of those claims and the total dollar value of the claims. Otherwise, skip this question. 
 fields:
   - 'Total contract claims': total_contract_claims
+    datatype: currency
+    help: |
+      [Provide instructions on calculating contact claims.]
   - 'Description of contract claims': description_of_claim
+    help: |
+      [Provide example description.]
 ---
 question: |
   Describe Plaintiff's injury
@@ -231,15 +235,20 @@ subquestion: |
   Include the nature and extent of injury.
 fields:
   - "Description of plaintiff's injury": description_plaintiff_injury
+    help: |
+      [Provide example injury description.] 
 ---
 continue button field: Does_Plaintiff_have_other_documented_damages
 question: |
   Does Plaintiff have other documented damages?
 subquestion: |
-  Placeholder text
+  If the Plaintiff incurred any other damages related to the actions covered in this claim, enter the total amount and describe the additional damages here. These damages [may] require documentation. 
 fields:
   - 'Other documented damages': documented_damages
+    datatype: currency
   - 'Description of other documented damages': documented_items_of_damages_other
+    help: |
+      [Provide examples of types of additional damages that can be listed here.]
 ---
 question: |
   Does this action include a claim involving collection of a debt?
@@ -248,7 +257,9 @@ subquestion: |
 yesno: collection_of_debt_yes
 ---
 question: |
-  Has a jury claim be made?
+  Has a jury claim been made?
+subquestion: |
+  [Have you, or someone on your behalf, made a jury claim for the amounts covered in this civil action?] 
 fields:
   - no label: jury_claim
     datatype: radio
@@ -263,10 +274,13 @@ code: |
 question: |
   Hidden logic
 subquestion: |
-  Calculated fields
+  Sub-total documented medical expenses to date: $( documented_medical_expenses_total)
 fields:
-  - 'Sub-total documented medical expenses to date': documented_medical_expenses_total
   - 'Total tort claims': total_tort_claims
+---
+code: |
+  documented_medical_expenses_total = documented_medical_expenses_chiropractic + documented_medical_expenses_doctor + documented_medical_expenses_hospital + documented_medical_expenses_other + documented_medical_expenses_physical_therapy
+  datatype: currency
 ---
 question: |
   Is there a claim under G.L. c. 93A?
@@ -300,9 +314,9 @@ code: |
 ---
 continue button field: Related_actions
 question: |
-  Related actions
+  Are there any actions related to this civil action pending in the Superior Court? 
 subquestion: |
-  Provide the case number, case name, and county of any related actions pending in the Superior Court.
+  Provide the case number, case name, and county of any related actions. If there are none, skip this question. 
 fields:
   - 'Description of related actions': related_actions
 ---
@@ -319,7 +333,7 @@ fields:
 question: |
   Type of action and track designation
 subquestion: |
-  Refer to (insert instruction page)
+  For instructions on how to fill out this section, refer to [Page 2 of the Civil Action Cover Sheet](https://www.mass.gov/files/documents/2016/08/tf/civil-action-cover-sheet-specific-counties.pdf).
 fields:
   - 'Code number': code_number
     required: False
@@ -329,80 +343,136 @@ fields:
     required: False
   - 'Description if other': description_if_other
     required: False
+# comment: I think the first three fields should be required because the user will need to fill those in. If not too complex, we may be able to include some show if logic for description if other?
 ---
-continue button field: What_are_Plaintiffs_anticipated_future_medical_and_hospital_expenses
+id: other_damages
 question: |
-  What are Plaintiff's anticipated future medical and hospital expenses?
+  Placeholder text: What are your other damages?
 subquestion: |
   Placeholder text
 fields:
   - 'Anticipated future medical expenses': anticipated_future_medical_expenses
----
-continue button field: What_are_Plaintiffs_anticipated_lost_wages
-question: |
-  What are Plaintiff's anticipated lost wages?
-subquestion: |
-  Placeholder text
-fields:
+    datatype: currency
+    help: |
+      [Provide details on how to calulate this number.]
   - 'Anticipated lost wages': anticipated_lost_wages
----
-continue button field: What_are_Plaintiffs_documented_lost_wages_and_compensation
-question: |
-  What are Plaintiff's documented lost wages and compensation?
-subquestion: |
-  Placeholder text
-fields:
+    datatype: currency
+    help: |
+      [Provide details on how to calculate this amount.]
   - 'Documented lost wages and compensation': documented_lost_wages
----
-continue button field: What_are_Plaintiffs_documented_property_damages_to_date
-question: |
-  What are Plaintiff's documented property damages to date?
-subquestion: |
-  Placeholder text
-fields:
+    datatype: currency
+    help: |
+      [Insert help text that explains lost wages and compensation.]
   - 'Documented property damages': documented_property_damages
+    datatype: currency
+    help: |
+      [Insert help text that describes property damages.] 
 ---
-continue button field: What_are_Plaintiffs_total_chiropractic_expenses
+#continue button field: What_are_Plaintiffs_anticipated_lost_wages
+#question: |
+#  What are Plaintiff's anticipated lost wages?
+#subquestion: |
+#  Enter the estimated amount, in dollars, of expected lost wages stemming from the actions covered by this claim.
+#fields:
+#  - 'Anticipated lost wages': anticipated_lost_wages
+#    help: |
+#      [Provide details on how to calculate this amount.]
+---
+#continue button field: What_are_Plaintiffs_documented_lost_wages_and_compensation
+#question: |
+#  What are Plaintiff's documented lost wages and compensation?
+#subquestion: |
+#  Enter the total amount, in dollars, of lost wages and compensation that occured as a result of the actions covered by this claim. You [may/will] need to provide documentation for this amount.
+#fields:
+#  - 'Documented lost wages and compensation': documented_lost_wages
+#    help: |
+#      [Insert help text that explains lost wages and compensation.]
+---
+#continue button field: What_are_Plaintiffs_documented_property_damages_to_date
+#question: |
+#  What are Plaintiff's documented property damages to date?
+#subquestion: |
+#  Enter the total cost, in dollars, of property damages that occured as a result of the actions covered by this claim. You [may/will] need to provide documentation for this amount.
+#fields:
+#  - 'Documented property damages': documented_property_damages
+#    help: |
+#      [Insert help text that describes property damages.]
+---
+#continue button field: #What_are_Plaintiffs_total_chiropractic_expenses
+#question: |
+#  What are Plaintiff's total chiropractic expenses?
+#subquestion: |
+#  Enter the total amount, in dollars, of documented chiropractic expenses incurred in connection with this claim.
+#fields:
+#  - 'Total documented chiropractic expenses': documented_medical_expenses_chiropractic
+#    datatype: currency
+#    help: |
+#      You can include all costs related to chiropractor visits. Do not include expenses that were charged by doctors, physical therapists, or other providers (they are covered separately).
+---
+#continue button field: #What_are_Plaintiffs_total_doctor_expenses
+#question: |
+#  What are Plaintiff's total doctor expenses?
+#subquestion: |
+#  Enter the total amount, in dollars, of documented expenses incurred visting doctors in connection with this claim.
+#fields:
+#  - 'Total documented doctor expenses': documented_medical_expenses_doctor
+#    datatype: currency
+#    help: |
+#      You can include all costs related to doctor visits. Do not include expenses that were charged by chiropractors, physical therapists, or other providers (they are covered separately).
+---
+id: documented_medical_expenses
 question: |
-  What are Plaintiff's total chiropractic expenses?
+  What are your documented medical expenses to date?
 subquestion: |
-  Placeholder text
+  Enter the total amount, in dollars, of documented hospital expenses incurred in connection with this claim. 
 fields:
-  - 'Total documented chiropractic expenses': documented_medical_expenses_chiropractic
+  - 'Hospital expenses': documented_medical_expenses_hospital
+    datatype: currency
+    help: |
+      You can include all expenses incurred with a hospital visit, like emergency room charges, supplies, overnight stays, etc. Do not include expenses that were charged by your doctor or ambulance company, chiropractor, or physical therapist (they are covered separately).
+  - 'Doctor expenses': documented_medical_expenses_doctor
+    datatype: currency
+    help: |
+      You can include all costs related to doctor visits. Do not include expenses that were charged by chiropractors, physical therapists, or other providers (they are covered separately).
+  - 'Chiropractic expenses': documented_medical_expenses_chiropractic
+    datatype: currency
+    help: |
+      You can include all costs related to chiropractor visits. Do not include expenses that were charged by doctors, physical therapists, or other providers (they are covered separately).
+  - 'Physical therapy expenses': documented_medical_expenses_physical_therapy
+    datatype: currency
+    help: |
+      You can include all expenses related to physical therapy. Do not include expenses that were charged by your hospital, ambulance company, chiropractor, or doctor (they are covered separately).
+  - 'Other documented medical expenses': documented_medical_expenses_other
+    datatype: currency
+    help: |
+      Include all documented medical expenses incurred in connection with this claim that have not been provided in the hospital, doctor, chiropractor, or physical therapy sections.
 ---
-continue button field: What_are_Plaintiffs_total_doctor_expenses
-question: |
-  What are Plaintiff's total doctor expenses?
-subquestion: |
-  Placeholder text
-fields:
-  - 'Total documented doctor expenses': documented_medical_expenses_doctor
+#continue button field: What_are_Plaintiffs_total_other_medical_expenses_not_already_provided
+#question: |
+#  What are Plaintiff's total other medical expenses not already provided?
+#subquestion: |
+#  Enter the total amount, in dollars, of other medical expenses incurred in connection with this claim.
+#fields:
+#  - 'Total other documented medical expenses': documented_medical_expenses_other
+#    datatype: currency
+#    help: |
+#      Include all documented medical expenses incurred in connection with this claim that have not been provided in the hospital, doctor, chiropractor, or physical therapy sections.
+
+---
+#continue button field: What_are_Plaintiffs_total_physical_therapy_expenses
+#question: |
+#  What are Plaintiff's total physical therapy expenses?
+#subquestion: |
+#  Enter the total amount, in dollars, of documented physical therapy expenses incurred in connection with this claim.
+#fields:
+#  - 'Total documented physical therapy expenses': documented_medical_expenses_physical_therapy
+#    datatype: currency
+#    help: |
+#      You can include all expenses related to physical therapy. Do not include expenses that were charged by your hospital, ambulance company, chiropractor, or doctor (they are covered separately).
+
 ---
 question: |
-  What are Plaintiff's total hospital expenses?
-subquestion: |
-  Placeholder text
-fields:
-  - 'Total documented hospital expenses': documented_medical_expenses_hospital
----
-continue button field: What_are_Plaintiffs_total_other_medical_expenses_not_already_provided
-question: |
-  What are Plaintiff's total other medical expenses not already provided?
-subquestion: |
-  Placeholder text
-fields:
-  - 'Total other documented medical expenses': documented_medical_expenses_other
----
-continue button field: What_are_Plaintiffs_total_physical_therapy_expenses
-question: |
-  What are Plaintiff's total physical therapy expenses?
-subquestion: |
-  Placeholder text
-fields:
-  - 'Total documented physical therapy expenses': documented_medical_expenses_physical_therapy
----
-question: |
-  What are details?
+  What are your details?
 subquestion: |
   Enter your registered address and BBO.
 fields:
@@ -487,7 +557,7 @@ attachment:
       - "collection_of_debt_yes": ${ collection_of_debt_yes }
       - "total_contract_claims": ${ total_contract_claims }
       - "description_of_claim": ${ description_of_claim }
-      - "user_signature_date": ${ user_signature_date }
+      - "user_signature_date": ${ users[0].signature_date }
       - "related_actions": ${ related_actions }
       - "certification_signature_date": ${ certification_signature_date }
       - "certification_signature": ${ certification_signature }
@@ -501,7 +571,7 @@ continue button field: Civil_Action_Cover_Sheet0026_intro
 question: |
   Civil Action Cover Sheet
 subquestion: |
-  Placeholder text
+  A civil cover sheet must be filed with each complaint in Superior Court.
 ---
 id: interview_order_Civil_Action_Cover_Sheet0026
 code: |
@@ -520,14 +590,7 @@ code: |
   claim_under_glc_93a_yes
   class_action_yes
   documented_medical_expenses_hospital
-  What_are_Plaintiffs_total_doctor_expenses
-  What_are_Plaintiffs_total_chiropractic_expenses
-  What_are_Plaintiffs_total_physical_therapy_expenses
-  What_are_Plaintiffs_total_other_medical_expenses_not_already_provided
-  What_are_Plaintiffs_documented_lost_wages_and_compensation
-  What_are_Plaintiffs_documented_property_damages_to_date
-  What_are_Plaintiffs_anticipated_future_medical_and_hospital_expenses
-  What_are_Plaintiffs_anticipated_lost_wages
+  anticipated_future_medical_expenses
   Does_Plaintiff_have_other_documented_damages
   description_plaintiff_injury
   collection_of_debt_yes
@@ -598,7 +661,6 @@ attachment:
       - "collection_of_debt_yes": ${ collection_of_debt_yes }
       - "total_contract_claims": ${ total_contract_claims }
       - "description_of_claim": ${ description_of_claim }
-      - "user_signature_date": ${ user_signature_date }
+      - "user_signature_date": ${ users[0].signature_date }
       - "related_actions": ${ related_actions }
       - "certification_signature_date": ${ certification_signature_date }
-      - "certification_signature": ${ certification_signature }

--- a/docassemble/MAVirtualCourt/data/questions/Civil_Action_Cover_Sheet.yml
+++ b/docassemble/MAVirtualCourt/data/questions/Civil_Action_Cover_Sheet.yml
@@ -4,9 +4,10 @@ code: |
   if not defined("interview_metadata['Civil_Action_Cover_Sheet0026']"):
     interview_metadata.initializeObject('Civil_Action_Cover_Sheet0026')
   interview_metadata['Civil_Action_Cover_Sheet0026'].update({
-    'title': 'Civil Action Cover Sheet',
+    'title': 'Civil Action Cover Sheet New Branch',
     'short title': 'Civil Action Cover Sheet',
-    'description': 'Placeholder text',
+    'description': 'A civil cover sheet must be filed with each complaint in Superior Court.',
+#Why is the description not pulling the updated description into the interview? How do we make it do this?
     'original_form': 'https://www.mass.gov/files/documents/2016/08/tf/civil-action-cover-sheet-specific-counties.pdf',
     'allowed courts': [
       'Superior Court',
@@ -217,16 +218,12 @@ code: |
 ---
 continue button field: Contract_claims
 question: |
-  Does this action involve contract claims?
+  Contract claims
 subquestion: |
-  If this civil action involves contract claims, provide a description of those claims and the total dollar value of the claims. Otherwise, skip this question. 
+  Describe the contract claims and provide the total dollar value of the claims.
 fields:
   - 'Total contract claims': total_contract_claims
-    help: |
-      [Provide instructions on calculating contact claims.]
   - 'Description of contract claims': description_of_claim
-    help: |
-      [Provide example description.]
 ---
 question: |
   Describe Plaintiff's injury
@@ -234,19 +231,15 @@ subquestion: |
   Include the nature and extent of injury.
 fields:
   - "Description of plaintiff's injury": description_plaintiff_injury
-    help: |
-      [Provide example injury description.] 
 ---
 continue button field: Does_Plaintiff_have_other_documented_damages
 question: |
   Does Plaintiff have other documented damages?
 subquestion: |
-  If the Plaintiff incurred any other damages related to the actions covered in this claim, enter the total amount and describe the additional damages here. These damages [may] require documentation. 
+  Placeholder text
 fields:
   - 'Other documented damages': documented_damages
   - 'Description of other documented damages': documented_items_of_damages_other
-    help: |
-      [Provide examples of types of additional damages that can be listed here.}
 ---
 question: |
   Does this action include a claim involving collection of a debt?
@@ -255,9 +248,7 @@ subquestion: |
 yesno: collection_of_debt_yes
 ---
 question: |
-  Has a jury claim been made?
-subquestion: |
-  [Have you, or someone on your behalf, made a jury claim for the amounts covered in this civil action?] 
+  Has a jury claim be made?
 fields:
   - no label: jury_claim
     datatype: radio
@@ -272,13 +263,10 @@ code: |
 question: |
   Hidden logic
 subquestion: |
-  Sub-total documented medical expenses to date: $( documented_medical_expenses_total)
+  Calculated fields
 fields:
+  - 'Sub-total documented medical expenses to date': documented_medical_expenses_total
   - 'Total tort claims': total_tort_claims
----
-code: |
-  documented_medical_expenses_total = documented_medical_expenses_chiropractic + documented_medical_expenses_doctor + documented_medical_expenses_hospital + documented_medical_expenses_other + documented_medical_expenses_physical_therapy
-  datatype: currency
 ---
 question: |
   Is there a claim under G.L. c. 93A?
@@ -312,9 +300,9 @@ code: |
 ---
 continue button field: Related_actions
 question: |
-  Are there any actions related to this civil action pending in the Superior Court? 
+  Related actions
 subquestion: |
-  Provide the case number, case name, and county of any related actions. If there are none, skip this question. 
+  Provide the case number, case name, and county of any related actions pending in the Superior Court.
 fields:
   - 'Description of related actions': related_actions
 ---
@@ -331,7 +319,7 @@ fields:
 question: |
   Type of action and track designation
 subquestion: |
-  For instructions on how to fill out this section, refer to [Page 2 of the Civil Action Cover Sheet](https://www.mass.gov/files/documents/2016/08/tf/civil-action-cover-sheet-specific-counties.pdf).
+  Refer to (insert instruction page)
 fields:
   - 'Code number': code_number
     required: False
@@ -346,100 +334,72 @@ continue button field: What_are_Plaintiffs_anticipated_future_medical_and_hospit
 question: |
   What are Plaintiff's anticipated future medical and hospital expenses?
 subquestion: |
-  Enter the estimated amount, in dollars, of expected future medical and hospital expenses related to the actions covered by this claim. 
+  Placeholder text
 fields:
   - 'Anticipated future medical expenses': anticipated_future_medical_expenses
-    datatype: currency
-    help: |
-      [Provide details on how to calulate this number.]
 ---
 continue button field: What_are_Plaintiffs_anticipated_lost_wages
 question: |
   What are Plaintiff's anticipated lost wages?
 subquestion: |
-  Enter the estimated amount, in dollars, of expected lost wages stemming from the actions covered by this claim.
+  Placeholder text
 fields:
   - 'Anticipated lost wages': anticipated_lost_wages
-    help: |
-      {Provide details on how to calculate this amount.]
 ---
 continue button field: What_are_Plaintiffs_documented_lost_wages_and_compensation
 question: |
   What are Plaintiff's documented lost wages and compensation?
 subquestion: |
-  Enter the total amount, in dollars, of lost wages and compensation that occured as a result of the actions covered by this claim. You [may/will] need to provide documentation for this amount.
+  Placeholder text
 fields:
   - 'Documented lost wages and compensation': documented_lost_wages
-    help: |
-      [Insert help text that explains lost wages and compensation.]
 ---
 continue button field: What_are_Plaintiffs_documented_property_damages_to_date
 question: |
   What are Plaintiff's documented property damages to date?
 subquestion: |
-  Enter the total cost, in dollars, of property damages that occured as a result of the actions covered by this claim. You [may/will] need to provide documentation for this amount.
+  Placeholder text
 fields:
   - 'Documented property damages': documented_property_damages
-    help: |
-      [Insert help text that describes property damages.]
 ---
 continue button field: What_are_Plaintiffs_total_chiropractic_expenses
 question: |
   What are Plaintiff's total chiropractic expenses?
 subquestion: |
-  Enter the total amount, in dollars, of documented chiropractic expenses incurred in connection with this claim.
+  Placeholder text
 fields:
   - 'Total documented chiropractic expenses': documented_medical_expenses_chiropractic
-    datatype: currency
-    help: |
-      You can include all costs related to chiropractor visits. Do not include expenses that were charged by doctors, physical therapists, or other providers (they are covered separately).
-
 ---
 continue button field: What_are_Plaintiffs_total_doctor_expenses
 question: |
   What are Plaintiff's total doctor expenses?
 subquestion: |
-  Enter the total amount, in dollars, of documented expenses incurred visting doctors in connection with this claim.
+  Placeholder text
 fields:
   - 'Total documented doctor expenses': documented_medical_expenses_doctor
-    datatype: currency
-    help: |
-      You can include all costs related to doctor visits. Do not include expenses that were charged by chiropractors, physical therapists, or other providers (they are covered separately).
 ---
 question: |
   What are Plaintiff's total hospital expenses?
 subquestion: |
-  Enter the total amount, in dollars, of documented hospital expenses incurred in connection with this claim.  
+  Placeholder text
 fields:
-  - 'Total hospital expenses': documented_medical_expenses_hospital
-    datatype: currency
-    help: |
-      You can include all expenses incurred with a hospital visit, like emergency room charges, supplies, overnight stays, etc. Do not include expenses that were charged by your doctor or ambulance company, chiropractor, or physical therapist (they are covered separately).
-
+  - 'Total documented hospital expenses': documented_medical_expenses_hospital
 ---
 continue button field: What_are_Plaintiffs_total_other_medical_expenses_not_already_provided
 question: |
   What are Plaintiff's total other medical expenses not already provided?
 subquestion: |
-  Enter the total amount, in dollars, of other medical expenses incurred in connection with this claim.
+  Placeholder text
 fields:
   - 'Total other documented medical expenses': documented_medical_expenses_other
-    datatype: currency
-    help: |
-      Include all documented medical expenses incurred in connection with this claim that have not been provided in the hospital, doctor, chiropractor, or physical therapy sections.
-
 ---
 continue button field: What_are_Plaintiffs_total_physical_therapy_expenses
 question: |
   What are Plaintiff's total physical therapy expenses?
 subquestion: |
-  Enter the total amount, in dollars, of documented physical therapy expenses incurred in connection with this claim.
+  Placeholder text
 fields:
   - 'Total documented physical therapy expenses': documented_medical_expenses_physical_therapy
-    datatype: currency
-    help: |
-      You can include all expenses related to physical therapy. Do not include expenses that were charged by your hospital, ambulance company, chiropractor, or doctor (they are covered separately).
-
 ---
 question: |
   What are details?
@@ -527,7 +487,7 @@ attachment:
       - "collection_of_debt_yes": ${ collection_of_debt_yes }
       - "total_contract_claims": ${ total_contract_claims }
       - "description_of_claim": ${ description_of_claim }
-      - "user_signature_date": ${ users[0].signature_date }
+      - "user_signature_date": ${ user_signature_date }
       - "related_actions": ${ related_actions }
       - "certification_signature_date": ${ certification_signature_date }
       - "certification_signature": ${ certification_signature }
@@ -541,7 +501,7 @@ continue button field: Civil_Action_Cover_Sheet0026_intro
 question: |
   Civil Action Cover Sheet
 subquestion: |
-  A civil cover sheet must be filed with each complaint in Superior Court.
+  Placeholder text
 ---
 id: interview_order_Civil_Action_Cover_Sheet0026
 code: |
@@ -638,6 +598,7 @@ attachment:
       - "collection_of_debt_yes": ${ collection_of_debt_yes }
       - "total_contract_claims": ${ total_contract_claims }
       - "description_of_claim": ${ description_of_claim }
-      - "user_signature_date": ${ users[0].signature_date }
+      - "user_signature_date": ${ user_signature_date }
       - "related_actions": ${ related_actions }
       - "certification_signature_date": ${ certification_signature_date }
+      - "certification_signature": ${ certification_signature }

--- a/docassemble/MAVirtualCourt/data/questions/Civil_Action_Cover_Sheet.yml
+++ b/docassemble/MAVirtualCourt/data/questions/Civil_Action_Cover_Sheet.yml
@@ -280,12 +280,12 @@ fields:
 ---
 code: |
   documented_medical_expenses_total = documented_medical_expenses_chiropractic + documented_medical_expenses_doctor + documented_medical_expenses_hospital + documented_medical_expenses_other + documented_medical_expenses_physical_therapy
-  datatype: currency
+# datatype: currency
 ---
 question: |
   Is there a claim under G.L. c. 93A?
 subquestion: |
-  Placeholder - Link to law: https://malegislature.gov/Laws/GeneralLaws/PartI/TitleXV/Chapter93A
+  [Additioanl information on claims made under G.L. c. 93A](https://malegislature.gov/Laws/GeneralLaws/PartI/TitleXV/Chapter93A)
 fields:
   - no label: claim_under_glc93a
     datatype: radio
@@ -300,7 +300,7 @@ code: |
 question: |
   Is this a class action under Mass. R. Civ. P. 23?
 subquestion: |
-  Placeholder - Link to law: https://www.mass.gov/rules-of-civil-procedure/civil-procedure-rule-23-class-actions
+  [Additional information on class actions under Mass. R. Civ. P. 23](https://www.mass.gov/rules-of-civil-procedure/civil-procedure-rule-23-class-actions)
 fields:
   - no label: class_action
     datatype: radio
@@ -596,7 +596,7 @@ code: |
   collection_of_debt_yes
   Contract_claims
   Related_actions
-  # documented_medical_expenses_total
+  documented_medical_expenses_total
   users[0].signature_date
   docket_numbers[0]
   str(plaintiffs[0])

--- a/docassemble/MAVirtualCourt/data/questions/Civil_Action_Cover_Sheet.yml
+++ b/docassemble/MAVirtualCourt/data/questions/Civil_Action_Cover_Sheet.yml
@@ -224,10 +224,10 @@ fields:
   - 'Total contract claims': total_contract_claims
     datatype: currency
     help: |
-      [Provide instructions on calculating contact claims.]
+      Provide instructions on calculating contact claims.
   - 'Description of contract claims': description_of_claim
     help: |
-      [Provide example description.]
+      Provide example description.
 ---
 question: |
   Describe Plaintiff's injury
@@ -236,19 +236,19 @@ subquestion: |
 fields:
   - "Description of plaintiff's injury": description_plaintiff_injury
     help: |
-      [Provide example injury description.] 
+      Provide example injury description.
 ---
 continue button field: Does_Plaintiff_have_other_documented_damages
 question: |
   Does Plaintiff have other documented damages?
 subquestion: |
-  If the Plaintiff incurred any other damages related to the actions covered in this claim, enter the total amount and describe the additional damages here. These damages [may] require documentation. 
+  If the Plaintiff incurred any other damages related to the actions covered in this claim, enter the total amount and describe the additional damages here. These damages may require documentation. 
 fields:
   - 'Other documented damages': documented_damages
     datatype: currency
   - 'Description of other documented damages': documented_items_of_damages_other
     help: |
-      [Provide examples of types of additional damages that can be listed here.]
+      Provide examples of types of additional damages that can be listed here.
 ---
 question: |
   Does this action include a claim involving collection of a debt?
@@ -259,7 +259,7 @@ yesno: collection_of_debt_yes
 question: |
   Has a jury claim been made?
 subquestion: |
-  [Have you, or someone on your behalf, made a jury claim for the amounts covered in this civil action?] 
+  Have you, or someone on your behalf, made a jury claim for the amounts covered in this civil action? 
 fields:
   - no label: jury_claim
     datatype: radio
@@ -274,7 +274,7 @@ code: |
 question: |
   Hidden logic
 subquestion: |
-  Sub-total documented medical expenses to date: $( documented_medical_expenses_total)
+  Sub-total documented medical expenses to date
 fields:
   - 'Total tort claims': total_tort_claims
 ---
@@ -354,19 +354,19 @@ fields:
   - 'Anticipated future medical expenses': anticipated_future_medical_expenses
     datatype: currency
     help: |
-      [Provide details on how to calulate this number.]
+      Provide details on how to calulate this number.
   - 'Anticipated lost wages': anticipated_lost_wages
     datatype: currency
     help: |
-      [Provide details on how to calculate this amount.]
+      Provide details on how to calculate this amount.
   - 'Documented lost wages and compensation': documented_lost_wages
     datatype: currency
     help: |
-      [Insert help text that explains lost wages and compensation.]
+      Insert help text that explains lost wages and compensation.
   - 'Documented property damages': documented_property_damages
     datatype: currency
     help: |
-      [Insert help text that describes property damages.] 
+      Insert help text that describes property damages.
 ---
 #continue button field: What_are_Plaintiffs_anticipated_lost_wages
 #question: |
@@ -596,7 +596,7 @@ code: |
   collection_of_debt_yes
   Contract_claims
   Related_actions
-  documented_medical_expenses_total
+  # documented_medical_expenses_total
   users[0].signature_date
   docket_numbers[0]
   str(plaintiffs[0])


### PR DESCRIPTION
I commented `documented_medical_expenses_total` out of the logic block in order to get the interview to run. I think we need to fix the block starting at line 274. 