### PR TITLE
Add ids, change yesno, remove docket number

### DIFF
--- a/docassemble/MAVirtualCourt/data/questions/Civil_Action_Cover_Sheet.yml
+++ b/docassemble/MAVirtualCourt/data/questions/Civil_Action_Cover_Sheet.yml
@@ -4,7 +4,7 @@ code: |
   if not defined("interview_metadata['Civil_Action_Cover_Sheet0026']"):
     interview_metadata.initializeObject('Civil_Action_Cover_Sheet0026')
   interview_metadata['Civil_Action_Cover_Sheet0026'].update({
-    'title': 'Civil Action Cover Sheet - intial',
+    'title': 'Civil Action Cover Sheet - intial commit MM',
     'short title': 'Civil Action Cover Sheet',
     'description': 'Placeholder text',
     'original_form': 'https://www.mass.gov/files/documents/2016/08/tf/civil-action-cover-sheet-specific-counties.pdf',

--- a/docassemble/MAVirtualCourt/data/questions/Civil_Action_Cover_Sheet.yml
+++ b/docassemble/MAVirtualCourt/data/questions/Civil_Action_Cover_Sheet.yml
@@ -593,9 +593,9 @@ code: |
   # Set the preferred/allowed courts for this interview
   preferred_court = interview_metadata["Civil_Action_Cover_Sheet0026"]["preferred court"]
   allowed_courts = interview_metadata["Civil_Action_Cover_Sheet0026"]["allowed courts"]
-  plaintiffs[0].address
-  attorneys[0].address
-  defendants[0].address
+  plaintiffs[0].address.address
+  attorneys[0].address.address
+  defendants[0].address.address
   jury_claim_made_yes
   code_number
   claim_under_glc_93a_yes

--- a/docassemble/MAVirtualCourt/data/questions/Civil_Action_Cover_Sheet.yml
+++ b/docassemble/MAVirtualCourt/data/questions/Civil_Action_Cover_Sheet.yml
@@ -215,7 +215,7 @@ code: |
       ],
   })
 ---
-continue button field: Contract_claims
+id: contract claims
 question: |
   Does this action involve contract claims?
 subquestion: |
@@ -237,15 +237,18 @@ code: |
   else:
     total_contract_claims = total_contract_claims
 ---
+id: plaintiff injury
 question: |
   Describe Plaintiff's injury
 subquestion: |
   Include the nature and extent of injury.
 fields:
   - "Description of plaintiff's injury": description_plaintiff_injury
+    required: false
     help: |
       Provide example injury description.
 ---
+id: other documented damages
 continue button field: Does_Plaintiff_have_other_documented_damages
 question: |
   Does Plaintiff have other documented damages?
@@ -260,12 +263,14 @@ fields:
     help: |
       Provide examples of types of additional damages that can be listed here.
 ---
+id: claim involving collection of debt
 question: |
   Does this action include a claim involving collection of a debt?
 subquestion: |
   The debt must be incurred pursuant to a revolving credit agreement. Mass. R. Civ. P. 8.1(a).
 yesno: collection_of_debt_yes
 ---
+id: jury claim
 question: |
   Has a jury claim been made?
 subquestion: |
@@ -292,6 +297,7 @@ code: |
   documented_medical_expenses_total = documented_medical_expenses_chiropractic + documented_medical_expenses_doctor + documented_medical_expenses_hospital + documented_medical_expenses_other + documented_medical_expenses_physical_therapy
   total_tort_claims = documented_medical_expenses_total + anticipated_future_medical_expenses + anticipated_lost_wages + documented_lost_wages + documented_property_damages + documented_damages
 ---
+id: claim under G.L. c. 93A
 question: |
   Is there a claim under G.L. c. 93A?
 subquestion: |
@@ -307,6 +313,7 @@ code: |
   claim_under_glc_93a_yes = claim_under_glc93a == "yes"
   claim_under_glc_93a_no = claim_under_glc93a == "no"
 ---
+id: class action
 question: |
   Is this a class action under Mass. R. Civ. P. 23?
 subquestion: |
@@ -322,6 +329,7 @@ code: |
   class_action_yes = class_action == "yes"
   class_action_no = class_action == "no"
 ---
+id: related actions
 continue button field: Related_actions
 question: |
   Are there any actions related to this civil action pending in the Superior Court? 
@@ -331,6 +339,7 @@ fields:
   - 'Description of related actions': related_actions
     required: False
 ---
+id: signature dates
 question: |
   Signature dates to do
 subquestion: |
@@ -341,6 +350,7 @@ fields:
   - 'Date of certification signature': certification_signature_date
     datatype: date
 ---
+id: action and track designation
 question: |
   Type of action and track designation
 subquestion: |
@@ -356,7 +366,7 @@ fields:
     required: False
 # comment: I think the first three fields should be required because the user will need to fill those in. If not too complex, we may be able to include some show if logic for description if other?
 ---
-id: other_damages
+id: other damages
 question: |
   Placeholder text: What are your other damages?
 subquestion: |
@@ -401,7 +411,7 @@ code: |
   else:
     anticipated_lost_wages = anticipated_lost_wages
 ---
-id: documented_medical_expenses
+id: documented medical expenses
 question: |
   What are your documented medical expenses to date?
 subquestion: |
@@ -489,6 +499,7 @@ fields:
   - 'Plaintiff address': plaintiffs[0].address
     input type: area
 ---
+id: download screen
 progress: 100
 mandatory: True
 question: |
@@ -559,8 +570,7 @@ attachment:
 include:
   - docassemble.MAVirtualCourt:basic-questions.yml
 ---
-comment: |
-  This question is used to introduce your interview. Please customize
+id: introduction page
 continue button field: Civil_Action_Cover_Sheet0026_intro
 question: |
   Civil Action Cover Sheet
@@ -587,7 +597,7 @@ code: |
   Does_Plaintiff_have_other_documented_damages
   description_plaintiff_injury
   collection_of_debt_yes
-  Contract_claims
+  total_contract_claims
   Related_actions
   documented_medical_expenses_total
   users[0].signature_date
@@ -605,6 +615,7 @@ code: |
   users[0].signature
   Civil_Action_Cover_Sheet0026 = True
 ---
+id: preview screen
 continue button field: Civil_Action_Cover_Sheet0026_preview_question
 question: |
   Placeholder preview screen

--- a/docassemble/MAVirtualCourt/data/questions/Civil_Action_Cover_Sheet.yml
+++ b/docassemble/MAVirtualCourt/data/questions/Civil_Action_Cover_Sheet.yml
@@ -534,7 +534,6 @@ attachment:
     filename: civil_action_cover_sheet
     pdf template file: Civil_Action_Cover_Sheet.pdf
     fields: 
-      - "docket_number": ${ docket_numbers[0] }
       - "plaintiff": ${ str(plaintiffs[0]) }
       - "court_county": ${ courts[0].address.county }
       - "defendant": ${ str(defendants[0]) }
@@ -610,7 +609,6 @@ code: |
   Related_actions
   documented_medical_expenses_total
   users[0].signature_date
-  docket_numbers[0]
   str(plaintiffs[0])
   courts[0].address.county
   str(defendants[0])
@@ -640,7 +638,6 @@ attachment:
     filename: Civil_Action_Cover_Sheet
     pdf template file: Civil_Action_Cover_Sheet.pdf
     fields: 
-      - "docket_number": ${ docket_numbers[0] }
       - "plaintiff": ${ str(plaintiffs[0]) }
       - "court_county": ${ courts[0].address.county }
       - "defendant": ${ str(defendants[0]) }

--- a/docassemble/MAVirtualCourt/data/questions/Civil_Action_Cover_Sheet.yml
+++ b/docassemble/MAVirtualCourt/data/questions/Civil_Action_Cover_Sheet.yml
@@ -268,7 +268,16 @@ question: |
   Does this action include a claim involving collection of a debt?
 subquestion: |
   The debt must be incurred pursuant to a revolving credit agreement. Mass. R. Civ. P. 8.1(a).
-yesno: collection_of_debt_yes
+fields:
+  - no label: collection_of_debt
+    datatype: radio
+    choices: 
+      - Yes: yes
+      - No: no
+---
+code: |
+  collection_of_debt_yes = collection_of_debt == "yes"
+  collection_of_debt_no = collection_of_debt == "no"
 ---
 id: jury claim
 question: |


### PR DESCRIPTION
- Added IDs to all questions
- Changed 'claim involving collection of debt' from yesno to radio button
- Removed "docket_number" to stop interview asking for docket number because the user will not know the docket number at time of filing. Court will allocate docket number upon filing.