### PR TITLE
Enhancements to interview

### DIFF
--- a/docassemble/MAVirtualCourt/data/questions/Civil_Action_Cover_Sheet.yml
+++ b/docassemble/MAVirtualCourt/data/questions/Civil_Action_Cover_Sheet.yml
@@ -4,7 +4,7 @@ code: |
   if not defined("interview_metadata['Civil_Action_Cover_Sheet0026']"):
     interview_metadata.initializeObject('Civil_Action_Cover_Sheet0026')
   interview_metadata['Civil_Action_Cover_Sheet0026'].update({
-    'title': 'Civil Action Cover Sheet - Initial',
+    'title': 'Civil Action Cover Sheet',
     'short title': 'Civil Action Cover Sheet',
     'description': 'Placeholder text',
     'original_form': 'https://www.mass.gov/files/documents/2016/08/tf/civil-action-cover-sheet-specific-counties.pdf',
@@ -268,32 +268,20 @@ question: |
   Does this action include a claim involving collection of a debt?
 subquestion: |
   The debt must be incurred pursuant to a revolving credit agreement. Mass. R. Civ. P. 8.1(a).
-fields:
-  - no label: collection_of_debt
-    datatype: radio
-    choices: 
-      - Yes: yes
-      - No: no
----
-code: |
-  collection_of_debt_yes = collection_of_debt == "yes"
-  collection_of_debt_no = collection_of_debt == "no"
+yesno: collection_of_debt_yes
+#Comment: Do not need 'no' to populate on PDF because there is only a checkbox for 'yes'.
 ---
 id: jury claim
 question: |
   Has a jury claim been made?
 subquestion: |
-  Have you, or someone on your behalf, made a jury claim for the amounts covered in this civil action? 
+  Have you, or someone on your behalf, made a jury claim for the amounts covered in this civil action?
 fields:
-  - no label: jury_claim
-    datatype: radio
-    choices:
-      - Yes: yes
-      - No: no
----
-code: |
-  jury_claim_made_yes = jury_claim == "yes"
-  jury_claim_made_no = jury_claim == "no"
+  - 'Yes': jury_claim_made_yes
+    datatype: yesno
+  - 'No': jury_claim_made_no
+    datatype: yesno
+#Comment: Need to make this required and change yesno to continue button.
 ---
 question: |
   Hidden logic
@@ -312,15 +300,11 @@ question: |
 subquestion: |
   [Additional information on claims made under G.L. c. 93A](https://malegislature.gov/Laws/GeneralLaws/PartI/TitleXV/Chapter93A)
 fields:
-  - no label: claim_under_glc93a
-    datatype: radio
-    choices:
-      - Yes: yes
-      - No: no
----
-code: |
-  claim_under_glc_93a_yes = claim_under_glc93a == "yes"
-  claim_under_glc_93a_no = claim_under_glc93a == "no"
+  - 'Yes': claim_under_glc_93a_yes
+    datatype: yesno
+  - 'No': claim_under_glc_93a_no
+    datatype: yesno
+#Comment: Need to make this required and change yesno to continue button.
 ---
 id: class action
 question: |
@@ -328,15 +312,11 @@ question: |
 subquestion: |
   [Additional information on class actions under Mass. R. Civ. P. 23](https://www.mass.gov/rules-of-civil-procedure/civil-procedure-rule-23-class-actions)
 fields:
-  - no label: class_action
-    datatype: radio
-    choices:
-      - Yes: yes
-      - No: no
----
-code: |
-  class_action_yes = class_action == "yes"
-  class_action_no = class_action == "no"
+  - 'Yes': class_action_yes
+    datatype: yesno
+  - 'No': class_action_no
+    datatype: yesno
+#Comment: Need to make this required and change yesno to continue button.
 ---
 id: related actions
 continue button field: Related_actions

--- a/docassemble/MAVirtualCourt/data/questions/Civil_Action_Cover_Sheet.yml
+++ b/docassemble/MAVirtualCourt/data/questions/Civil_Action_Cover_Sheet.yml
@@ -276,12 +276,7 @@ question: |
   Has a jury claim been made?
 subquestion: |
   Have you, or someone on your behalf, made a jury claim for the amounts covered in this civil action?
-fields:
-  - 'Yes': jury_claim_made_yes
-    datatype: yesno
-  - 'No': jury_claim_made_no
-    datatype: yesno
-#Comment: Need to make this required and change yesno to continue button.
+yesno: jury_claim_made_yes
 ---
 question: |
   Hidden logic
@@ -299,24 +294,14 @@ question: |
   Is there a claim under G.L. c. 93A?
 subquestion: |
   [Additional information on claims made under G.L. c. 93A](https://malegislature.gov/Laws/GeneralLaws/PartI/TitleXV/Chapter93A)
-fields:
-  - 'Yes': claim_under_glc_93a_yes
-    datatype: yesno
-  - 'No': claim_under_glc_93a_no
-    datatype: yesno
-#Comment: Need to make this required and change yesno to continue button.
+yesno: claim_under_glc_93a_yes
 ---
 id: class action
 question: |
   Is this a class action under Mass. R. Civ. P. 23?
 subquestion: |
   [Additional information on class actions under Mass. R. Civ. P. 23](https://www.mass.gov/rules-of-civil-procedure/civil-procedure-rule-23-class-actions)
-fields:
-  - 'Yes': class_action_yes
-    datatype: yesno
-  - 'No': class_action_no
-    datatype: yesno
-#Comment: Need to make this required and change yesno to continue button.
+yesno: class_action_yes
 ---
 id: related actions
 continue button field: Related_actions
@@ -524,15 +509,15 @@ attachment:
       - "bbo_number": ${ bbo_number }
       - "defendant_address": ${ defendants[0].address }
       - "jury_claim_made_yes": ${ jury_claim_made_yes }
-      - "jury_claim_made_no": ${ jury_claim_made_no }
+      - "jury_claim_made_no": ${ not jury_claim_made_yes }
       - "code_number": ${ code_number }
       - "type_of_action": ${ type_of_action }
       - "track": ${ track }
       - "description_if_other": ${ description_if_other }
       - "class_action_yes": ${ class_action_yes }
       - "claim_under_glc_93a_yes": ${ claim_under_glc_93a_yes }
-      - "class_action_no": ${ class_action_no }
-      - "claim_under_glc_93a_no": ${ claim_under_glc_93a_no }
+      - "class_action_no": ${ not class_action_yes }
+      - "claim_under_glc_93a_no": ${ not claim_under_glc_93a_yes }
       - "documented_medical_expenses_hospital": ${ f'{int(round(documented_medical_expenses_hospital)):,}' }
       - "documented_medical_expenses_doctor": ${ f'{int(round(documented_medical_expenses_doctor )):,}' }
       - "documented_medical_expenses_chiropractic": ${ f'{int(round(documented_medical_expenses_chiropractic )):,}' }
@@ -627,15 +612,15 @@ attachment:
       - "bbo_number": ${ bbo_number }
       - "defendant_address": ${ defendants[0].address }
       - "jury_claim_made_yes": ${ jury_claim_made_yes }
-      - "jury_claim_made_no": ${ jury_claim_made_no }
+      - "jury_claim_made_no": ${ not jury_claim_made_yes }
       - "code_number": ${ code_number }
       - "type_of_action": ${ type_of_action }
       - "track": ${ track }
       - "description_if_other": ${ description_if_other }
       - "class_action_yes": ${ class_action_yes }
       - "claim_under_glc_93a_yes": ${ claim_under_glc_93a_yes }
-      - "class_action_no": ${ class_action_no }
-      - "claim_under_glc_93a_no": ${ claim_under_glc_93a_no }
+      - "class_action_no": ${ not class_action_yes }
+      - "claim_under_glc_93a_no": ${ not claim_under_glc_93a_yes }
       - "documented_medical_expenses_hospital": ${ f'{int(round(documented_medical_expenses_hospital)):,}' }
       - "documented_medical_expenses_doctor": ${ f'{int(round(documented_medical_expenses_doctor )):,}' }
       - "documented_medical_expenses_chiropractic": ${ f'{int(round(documented_medical_expenses_chiropractic )):,}' }

--- a/docassemble/MAVirtualCourt/data/questions/Civil_Action_Cover_Sheet.yml
+++ b/docassemble/MAVirtualCourt/data/questions/Civil_Action_Cover_Sheet.yml
@@ -4,7 +4,7 @@ code: |
   if not defined("interview_metadata['Civil_Action_Cover_Sheet0026']"):
     interview_metadata.initializeObject('Civil_Action_Cover_Sheet0026')
   interview_metadata['Civil_Action_Cover_Sheet0026'].update({
-    'title': 'Civil Action Cover Sheet - intial commit MM',
+    'title': 'Civil Action Cover Sheet - Initial',
     'short title': 'Civil Action Cover Sheet',
     'description': 'Placeholder text',
     'original_form': 'https://www.mass.gov/files/documents/2016/08/tf/civil-action-cover-sheet-specific-counties.pdf',

--- a/docassemble/MAVirtualCourt/data/questions/Civil_Action_Cover_Sheet.yml
+++ b/docassemble/MAVirtualCourt/data/questions/Civil_Action_Cover_Sheet.yml
@@ -219,6 +219,37 @@ code: |
       ],
   })
 ---
+objects:
+  - attorney: VCIndividual
+---
+id: representation
+question: |
+  Representation
+subquestion: |
+  Placeholder text
+fields:
+  - Are you representing yourself?: is_self_represented
+    datatype: yesnoradio
+  - 'Attorney BBO Number': users[0].bbo_number
+    show if:
+      variable: is_self_represented
+      is: False
+---
+id: name of attorney
+question: |
+  You are the attorney. Tell us your name below and we will ask for the Plaintiff's name later.
+subquestion: |
+  Placeholder text.
+fields:
+  - First name: attorney.name.first
+  - Middle name: attorney.name.middle
+    required: False
+  - Last name: attorney.name.last
+  - Suffix: attorney.name.suffix
+    code: |
+      name_suffix()
+    required: False
+---
 id: contract claims
 question: |
   Does this action involve contract claims?
@@ -448,7 +479,7 @@ question: |
 subquestion: |
   Enter your registered address and BBO.
 fields:
-  - 'Attorney address': attorneys[0].address
+  - 'Attorney address': attorney.address
     input type: area
     required: False
   - 'BBO number': bbo_number
@@ -464,9 +495,9 @@ fields:
 
 
 question: |
-  Sign below, ${attorneys}
+  Sign below, ${attorney}
 under: |
-  ${attorneys}
+  ${attorney}
 signature: certification_signature
 ---
 question: |
@@ -591,10 +622,10 @@ attachment:
       - "plaintiff": ${ str(plaintiffs[0]) }
       - "court_county": ${ courts[0].address.county }
       - "defendant": ${ str(defendants[0]) }
-      - "attorney": ${ str(attorneys[0]) }
+      - "attorney": ${ attorney }
       - "user_signature": ${ users[0].signature }
       - "plaintiff_address": ${ plaintiffs[0].address }
-      - "attorney_address": ${ attorneys[0].address }
+      - "attorney_address": ${ attorney.address }
       - "bbo_number": ${ bbo_number }
       - "defendant_address": ${ defendants[0].address }
       - "jury_claim_made_yes": ${ jury_claim_made_yes }
@@ -644,8 +675,9 @@ code: |
   # Set the preferred/allowed courts for this interview
   preferred_court = interview_metadata["Civil_Action_Cover_Sheet0026"]["preferred court"]
   allowed_courts = interview_metadata["Civil_Action_Cover_Sheet0026"]["allowed courts"]
+  is_self_represented
   plaintiffs[0].address.address
-  attorneys[0].address.address
+  attorney.address.address
   defendants[0].address.address
   jury_claim_made_yes
   code_number
@@ -663,7 +695,7 @@ code: |
   str(plaintiffs[0])
   courts[0].address.county
   str(defendants[0])
-  str(attorneys[0])
+  str(attorney)
   # By default, we'll mark any un-filled fields as DAEmpty(). This helps avoid errors if you intentionally hide a logic branch or mark a question not required
   # Comment out the line below if you don't want this behavior. 
   # mark_unfilled_fields_empty(interview_metadata["Civil_Action_Cover_Sheet0026"])
@@ -693,9 +725,9 @@ attachment:
       - "plaintiff": ${ str(plaintiffs[0]) }
       - "court_county": ${ courts[0].address.county }
       - "defendant": ${ str(defendants[0]) }
-      - "attorney": ${ str(attorneys[0]) }
+      - "attorney": ${ attorney }
       - "plaintiff_address": ${ plaintiffs[0].address }
-      - "attorney_address": ${ attorneys[0].address }
+      - "attorney_address": ${ attorney.address }
       - "bbo_number": ${ bbo_number }
       - "defendant_address": ${ defendants[0].address }
       - "jury_claim_made_yes": ${ jury_claim_made_yes }

--- a/docassemble/MAVirtualCourt/data/questions/Civil_Action_Cover_Sheet.yml
+++ b/docassemble/MAVirtualCourt/data/questions/Civil_Action_Cover_Sheet.yml
@@ -1,3 +1,7 @@
+---
+include:
+  - docassemble.MAVirtualCourt:basic-questions.yml
+---
 mandatory: True
 code: |
   interview_metadata # make sure we initialize the object
@@ -539,9 +543,6 @@ attachment:
       - "related_actions": ${ related_actions }
       - "certification_signature_date": ${ certification_signature_date }
       - "certification_signature": ${ certification_signature }
----
-include:
-  - docassemble.MAVirtualCourt:basic-questions.yml
 ---
 id: introduction page
 continue button field: Civil_Action_Cover_Sheet0026_intro

--- a/docassemble/MAVirtualCourt/data/questions/Civil_Action_Cover_Sheet.yml
+++ b/docassemble/MAVirtualCourt/data/questions/Civil_Action_Cover_Sheet.yml
@@ -366,11 +366,11 @@ subquestion: |
   For instructions on how to fill out this section, refer to [Page 2 of the Civil Action Cover Sheet](https://www.mass.gov/files/documents/2016/08/tf/civil-action-cover-sheet-specific-counties.pdf).
 fields:
   - 'Code number': code_number
-    required: False
+    required: True
   - 'Type of action': type_of_action
-    required: False
+    required: True
   - 'Track': track
-    required: False
+    required: True
   - 'Description if other': description_if_other
     required: False
 # comment: I think the first three fields should be required because the user will need to fill those in. If not too complex, we may be able to include some show if logic for description if other?

--- a/docassemble/MAVirtualCourt/data/questions/Civil_Action_Cover_Sheet.yml
+++ b/docassemble/MAVirtualCourt/data/questions/Civil_Action_Cover_Sheet.yml
@@ -495,6 +495,91 @@ subquestion: |
   ${Civil_Action_Cover_Sheet0026_attachment }
 attachment code: Civil_Action_Cover_Sheet0026_attachment
 ---
+event: review_all_sections
+question: |
+  Review of your answers
+subquestion: |
+  ${showifdef('form_to_sign')}
+  % if defined('form_delivery_complete'):
+  **Warning: your form has already been delivered.** Any changes you make
+  will _not_ be sent to the court.
+  % endif
+  Click a section to revisit the answers from that section.
+  % for section in section_links(nav):
+  * ${section}
+  % endfor
+  Press "${word("Resume")}" to resume the
+  interview.
+buttons:
+  ${word("Resume")}: continue
+---
+id: review before signature
+need: form_to_sign
+continue button field: preview_screen
+question: |
+  Nearly finished
+subquestion: |
+  You are almost done! Please click on the form below. It will open in a new window so you can review it and make sure it is correct.
+  Don't forget to come back to this page to click to the final step of signing and sending the form to the court. 
+   ${form_to_sign }
+progress: 95
+---
+id: download form
+event: download
+comment: |
+  The attachment email screen relies on final_form_to_file being defined. This
+  will be built from the interview_metadata dictionary's contents, but if you
+  add any addenda you will want to set this in a code block somewhere that takes
+  priority over basic-questions.yml.
+decoration: file-download
+question: |
+  % if not defined('email_success') or not email_success:
+  Review, Download, and Send Form
+  % else:
+  Form delivered
+  % endif
+subquestion: |
+  % if not defined('email_success') or not email_success:
+  Thank you ${users[0]}. Your form is ready to send to the court. **It is not
+  delivered until you complete the delivery process below.**
+  1. Click the preview image below to open the form in a new window. Correct any errors using the "Make changes" button below.
+  2. Download and save or print a copy of this form for your 
+  records.
+  3. Click the "Submit to ${courts[0]}" button to send it to the court. 
+  4. You will have a chance to add instructions to the clerk and see the cover page before final delivery.
+  % else:
+  If you do not hear from the court in 1 business day, call the Trial Court's
+  Emergency HelpLine 833-91-COURT (833-912-6878).
+  The Emergency HelpLine is open:  
+  8:30am - 4:30pm,   
+  Monday - Friday.
+  % endif
+  ${ form_to_file_no_cover }  
+  ${action_button_html(url_action('review_all_sections'), icon='edit', label=word("Make changes"))}
+  % if not defined('email_success') or not email_success:
+    ${ action_button_html( url_action('form_delivery_complete'), id_tag="submitToCourt", label="Submit to " + str(courts[0].name), icon=send_icon, size="md", color="primary")}
+  Or download/email below:
+  % else:
+    Your email has already been delivered to ${courts[0]}
+  [:file-download: Download with cover page](${final_form_to_file.url_for()})    
+  % endif
+progress: 100
+attachment code: Civil_Action_Cover_Sheet0026_attachment
+section: download
+---
+progress: 100
+mandatory: False
+question: |
+  Placeholder download screen
+subquestion: |
+  Placeholder
+  ### Next steps
+  1. Step 1
+  1. Step 2
+  Below is a preview of your form.
+  ${ Civil_Action_Cover_Sheet0026_attachment }
+attachment code: Civil_Action_Cover_Sheet0026_attachment
+---
 need: Civil_Action_Cover_Sheet0026
 attachment:
     variable name: Civil_Action_Cover_Sheet0026_attachment
@@ -587,6 +672,7 @@ code: |
   basic_questions_signature_flow
   users[0].signature
   Civil_Action_Cover_Sheet0026 = True
+  download
 ---
 id: preview screen
 continue button field: Civil_Action_Cover_Sheet0026_preview_question


### PR DESCRIPTION
- Made `id: action and track designation` required.
- Changed radio buttons to yesno fields (`id: jury claim`, `id: claim under G.L. c. 93A`, `id: class action`, `id: claim involving the collection of debt`).
- Changed continue button to yesno fields (`id: jury claim`, `id: claim under G.L. c. 93A`, `id: class action`)
- Brought include: basic-questions to the top of the interview to trigger accessibility audio bar
- Added code for submission to court option and coversheet
- Added question to ask if user is self-represented and then changed asking attorney's name. Need to work on this language.