### PR TITLE
Added missing "as"

### DIFF
--- a/docassemble/MAVirtualCourt/data/questions/209A_affidavit.yml
+++ b/docassemble/MAVirtualCourt/data/questions/209A_affidavit.yml
@@ -566,7 +566,7 @@ question: |
   This is your Affidavit 
 subquestion: |
   These are your words. Edit this statement in any way you need so that it says exactly what you need to tell the judge.  
-  Once you are satisfied you have told the truth, as far you know, go on to the next set of questions.
+  Once you are satisfied you have told the truth, as far as you know, go on to the next set of questions.
 # The affidavit will start with this text:
 
 # > The following is a brief summary of the events 


### PR DESCRIPTION
When showing the affidavit for review the user was prompted "Once you are satisfied you have told the truth, as far you know, go on to the next set of questions." I added an as to make this "Once you are satisfied you have told the truth, as far as you know, go on to the next set of questions."