### PR TITLE
Remove required status for zip codes

### DIFF
--- a/docassemble/MAVirtualCourt/data/questions/209A_affidavit_disclosing_care_or_custody_proceedings.yml
+++ b/docassemble/MAVirtualCourt/data/questions/209A_affidavit_disclosing_care_or_custody_proceedings.yml
@@ -239,6 +239,7 @@ fields:
       states_list()
     default: "MA"
   - Zip: children[i].previous_addresses[j].zip
+    required: False
 ---
 id: child has another past address
 question: |
@@ -900,6 +901,7 @@ fields:
     code: |
       states_list()
   - Zip: signing_attorney.address.zip
+    required: False
 #---
 #question: |
 #  Date

--- a/docassemble/MAVirtualCourt/data/questions/209A_complaint_for_protection_from_abuse_probation.yml
+++ b/docassemble/MAVirtualCourt/data/questions/209A_complaint_for_protection_from_abuse_probation.yml
@@ -610,7 +610,8 @@ fields:
     code: |
       states_list()
     default: MA      
-  - Zip: schools_to_stay_away_from[i].address.zip 
+  - Zip: schools_to_stay_away_from[i].address.zip
+    required: False
 # ---
 # id: wants_to_request_visitation_details
 # question: |

--- a/docassemble/MAVirtualCourt/data/questions/basic-questions.yml
+++ b/docassemble/MAVirtualCourt/data/questions/basic-questions.yml
@@ -274,7 +274,8 @@ fields:
     code: |
       states_list()
     default: MA      
-  - Zip: users[0].address.zip 
+  - Zip: users[0].address.zip
+    required: False
 ---
 id: your contact information
 question: |
@@ -495,6 +496,7 @@ fields:
     code: |
       states_list()   
   - Zip: x.address.zip
+    required: False
 ---
 id: persons address
 generic object: Individual
@@ -511,6 +513,7 @@ fields:
     code: |
       states_list()   
   - Zip: x.address.zip
+    required: False
 ---
 id: persons contact information
 generic object: Individual

--- a/docassemble/MAVirtualCourt/data/questions/defendant-information-209A.yml
+++ b/docassemble/MAVirtualCourt/data/questions/defendant-information-209A.yml
@@ -596,7 +596,8 @@ fields:
     default: MA   
     code: |
       states_list()   
-  - Zip: other_parties[0].address.zip  
+  - Zip: other_parties[0].address.zip
+    required: False
   - Cell phone: other_parties[0].mobile_number    
     maxlength: 14
     required: False

--- a/docassemble/MAVirtualCourt/data/questions/motion-for-impoundment.yml
+++ b/docassemble/MAVirtualCourt/data/questions/motion-for-impoundment.yml
@@ -164,7 +164,7 @@ help:
     ${ other_parties.familiar() }’s lawyer and 
     * will be available to you, your lawyer, people you give the court permission to show, and to certain persons who may need this information so they can do their job. These are prosecutors, law enforcement officers, victim-witness advocates, sexual assault counselors and domestic violence counselors.
     
-    If you asked the court to order  ${ other_parties.familiar() } to stay away from your home, work or school, the order will say ${ other_parties.familiar() } must stay away from your home, work or school, "whereever that may be."
+    If you asked the court to order  ${ other_parties.familiar() } to stay away from your home, work or school, the order will say ${ other_parties.familiar() } must stay away from your home, work or school, "wherever that may be."
     
     If you need the court not to share this information with people who normally see the information to do their jobs, you may ask the judge to issue an Order of Impoundment. 
     

--- a/docassemble/MAVirtualCourt/data/questions/plaintiff-confidential.yml
+++ b/docassemble/MAVirtualCourt/data/questions/plaintiff-confidential.yml
@@ -290,7 +290,8 @@ fields:
     code: |
       states_list()
     default: MA      
-  - Zip: users[0].address.zip 
+  - Zip: users[0].address.zip
+    required: False
   - I live at more than one address: users[0].other_addresses.there_are_any
     datatype: yesno
 ---
@@ -312,7 +313,8 @@ fields:
     code: |
       states_list()
     default: MA      
-  - Zip: users[0].other_addresses[i].zip 
+  - Zip: users[0].other_addresses[i].zip
+    required: False
 ---
 id: has another other address
 question: |


### PR DESCRIPTION
They're not needed to deliver mail and don't need to be an obstacle for the user. I believe I found all of them.

I also accidentally corrected a typo and deleted whitespace at the end of zip code field lines. I apologize.