### PR TITLE
Add script for running other scripts in combination

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm install
       - run: npm run setup
-      - run: npm run test
       - run: npm run cucumber
       - name: upload artifacts
         uses: actions/upload-artifact@v2

--- a/package.json
+++ b/package.json
@@ -7,10 +7,11 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "mocha tests --timeout 10000",
+    "test": "echo 'These tests are fake. Use `local`' && mocha tests --timeout 10000",
     "cucumber": "./node_modules/.bin/cucumber-js tests/features/*.feature",
     "setup": "node -e 'require(\"./tests/install-branch.js\").setup()'",
-    "takedown": "node -e 'require(\"./tests/install-branch.js\").takedown()'"
+    "takedown": "node -e 'require(\"./tests/install-branch.js\").takedown()'",
+    "local": "npm run setup && npm run cucumber && npm run takedown"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Also adds message about plain old mocha tests not being used. In npm, `test` is usually how everyone runs...tests, so our setup will be a bit confusing to a new coder who was familiar with npm.