### PR TITLE
Close user issues we can't address on creation

### DIFF
--- a/.github/workflows/auto_close_empty_issues.yml
+++ b/.github/workflows/auto_close_empty_issues.yml
@@ -1,0 +1,16 @@
+name: Close feedback issues that are always empty
+# See https://github.com/marketplace/actions/issue-title-checker
+
+on:
+  issues:
+    types: [opened]
+jobs:   
+  auto_close:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Automatically close user issues we can't address (more help wanted)
+      uses: IndyV/IssueChecker@v1.0
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        issue-close-message: "This issue was automatically closed because it has no content"
+        issue-pattern: "User: I'm looking for more help"


### PR DESCRIPTION
There's no input from the feedback issues created when users want more help because we aren't able to help, so close those automatically.

See test repo https://github.com/plocket/auto_close to test it out. That repo also has an extra action step to log the name of the issue title. It was just for development. This PR doesn't have that extra step.