### PR TITLE
Testing: Follows #673. Mainly separates concerns of button presses and navigation

### DIFF
--- a/tests/features/intro.feature
+++ b/tests/features/intro.feature
@@ -44,5 +44,5 @@ Scenario: Can't continue without accepting terms
 
 Scenario: Can continue after accepting terms
   Given I start the interview
-  When I click the option with the text "I accept"
+  When I tap the option with the text "I accept"
   Then I continue to the next page

--- a/tests/features/intro.feature
+++ b/tests/features/intro.feature
@@ -39,10 +39,12 @@ Scenario: Accept terms starts as unchecked
 Scenario: Can't continue without accepting terms
   Given I start the interview
   When I do nothing
+  Then I tap the button "Next"
   Then I can't continue
   Then I will be told an answer is invalid
 
 Scenario: Can continue after accepting terms
   Given I start the interview
   When I tap the option with the text "I accept"
-  Then I continue to the next page
+  Then I tap the button "Next"
+  Then I arrive at the next page

--- a/tests/features/intro.feature
+++ b/tests/features/intro.feature
@@ -44,5 +44,5 @@ Scenario: Can't continue without accepting terms
 
 Scenario: Can continue after accepting terms
   Given I start the interview
-  When I check the "I accept" checkbox
+  When I click the option with the text "I accept"
   Then I continue to the next page

--- a/tests/features/support/steps.js
+++ b/tests/features/support/steps.js
@@ -38,7 +38,7 @@ regex thoughts: https://stackoverflow.com/questions/171480/regex-grabbing-values
 
 
 const INTERVIEW_URL = interviewConstants.INTERVIEW_URL;
-setDefaultTimeout(120 * 1000);
+setDefaultTimeout(5 * 1000);
 
 let device_touch_map = {
   mobile: 'tap',
@@ -57,7 +57,7 @@ Given(/I start the interview[ on ]?(.*)/, async (optional_device) => {
 
   if (!scope.page) {
     scope.page = await scope.browser.newPage();
-    scope.page.setDefaultTimeout(120 * 1000)
+    scope.page.setDefaultTimeout(5 * 1000)
   }
 
   // Let developer pick mobile device if they want to

--- a/tests/features/support/steps.js
+++ b/tests/features/support/steps.js
@@ -241,7 +241,7 @@ Then('I continue to the next page', async () => {
 //#####################################
 
 When('I click the defined text link {string}', async (phrase) => {
-  /* Clicks on link with exact matching text, I think */
+  /* Not sure what 'defined' means here */
   const [link] = await scope.page.$x(`//a[contains(text(), "${phrase}")]`);
   if (link) {
     await link.click();  // TODO: change to `clickOrTap`
@@ -262,23 +262,21 @@ When('I click the defined text link {string}', async (phrase) => {
 //   }
 // );
 
-When(/I check the "([^"]+)" checkbox/, async (label_text) => {
-  /* Clicks the first checkbox with the label "containing" the "label text".
+When(/I click the option with the text "([^"]+)"/, async (label_text) => {
+  /* Clicks the first element with the label "containing" the "label text".
   *    Very limited. Anything more is a future feature.
-  * 
-  * "checkbox": label that contains checkbox-like behavior.
   * 
   * May switch to using the below instead - almost same code, but
   *    its text has to match exactly and it turns out clicking labels
   *    works for more than one thing.
   */
-  let checkbox = await scope.page.waitFor( `label[aria-label*="${ label_text }"]` );
-  await checkbox.click();
+  let choice = await scope.page.waitFor( `label[aria-label*="${ label_text }"]` );
+  await choice.click();
 
   await scope.waitForShowIf(scope);
 });
 
-When('I pick the {string} option', async (label_text) => {
+When('I click the {string} option', async (label_text) => {
   /* Clicks the first label with the exact `label_text`.
   *    Very limited. Anything more is a future feature.
   */

--- a/tests/features/support/steps.js
+++ b/tests/features/support/steps.js
@@ -38,7 +38,7 @@ regex thoughts: https://stackoverflow.com/questions/171480/regex-grabbing-values
 
 
 const INTERVIEW_URL = interviewConstants.INTERVIEW_URL;
-setDefaultTimeout(5 * 1000);
+setDefaultTimeout(120 * 1000);
 
 let device_touch_map = {
   mobile: 'tap',
@@ -57,7 +57,7 @@ Given(/I start the interview[ on ]?(.*)/, async (optional_device) => {
 
   if (!scope.page) {
     scope.page = await scope.browser.newPage();
-    scope.page.setDefaultTimeout(5 * 1000)
+    scope.page.setDefaultTimeout(120 * 1000)
   }
 
   // Let developer pick mobile device if they want to

--- a/tests/features/user_court_contact_info.feature
+++ b/tests/features/user_court_contact_info.feature
@@ -13,20 +13,20 @@ Tests:
 
 Scenario: User contact info page should exist
   Given I start the interview
-  When I check the "I accept" checkbox
+  When I click the option with the text "I accept"
   Then I continue to the next page
   Then the question id should be "your contact information"
 
 Scenario: Can't continue if gave no information
   Given I start the interview
-  When I check the "I accept" checkbox
+  When I click the option with the text "I accept"
   Then I continue to the next page
   When I do nothing
   Then I can't continue
   
 Scenario: Get invalidation message if gave no information
   Given I start the interview
-  When I check the "I accept" checkbox
+  When I click the option with the text "I accept"
   Then I continue to the next page
   When I do nothing
   Then I can't continue
@@ -34,28 +34,28 @@ Scenario: Get invalidation message if gave no information
 
 Scenario: Giving a mobile number will allow the user to continue
   Given I start the interview
-  When I check the "I accept" checkbox
+  When I click the option with the text "I accept"
   Then I continue to the next page
   Then I type "201 555-0123" in the "Mobile number" field
   Then I continue to the next page
 
 Scenario: Giving another phone number will allow the user to continue
   Given I start the interview
-  When I check the "I accept" checkbox
+  When I click the option with the text "I accept"
   Then I continue to the next page
   Then I type "201 555-0123" in the "Other phone number" field
   Then I continue to the next page
 
 Scenario: Giving an email will allow the user to continue
   Given I start the interview
-  When I check the "I accept" checkbox
+  When I click the option with the text "I accept"
   Then I continue to the next page
   Then I type "user@example.com" in the "Email address" field
   Then I continue to the next page
 
 Scenario: Giving other contact info will allow the user to continue
   Given I start the interview
-  When I check the "I accept" checkbox
+  When I click the option with the text "I accept"
   Then I continue to the next page
   Then I type "Semaphore" in the "Other ways to reach you" field
   Then I continue to the next page

--- a/tests/features/user_court_contact_info.feature
+++ b/tests/features/user_court_contact_info.feature
@@ -13,20 +13,20 @@ Tests:
 
 Scenario: User contact info page should exist
   Given I start the interview
-  When I click the option with the text "I accept"
+  When I tap the option with the text "I accept"
   Then I continue to the next page
   Then the question id should be "your contact information"
 
 Scenario: Can't continue if gave no information
   Given I start the interview
-  When I click the option with the text "I accept"
+  When I tap the option with the text "I accept"
   Then I continue to the next page
   When I do nothing
   Then I can't continue
   
 Scenario: Get invalidation message if gave no information
   Given I start the interview
-  When I click the option with the text "I accept"
+  When I tap the option with the text "I accept"
   Then I continue to the next page
   When I do nothing
   Then I can't continue
@@ -34,28 +34,28 @@ Scenario: Get invalidation message if gave no information
 
 Scenario: Giving a mobile number will allow the user to continue
   Given I start the interview
-  When I click the option with the text "I accept"
+  When I tap the option with the text "I accept"
   Then I continue to the next page
   Then I type "201 555-0123" in the "Mobile number" field
   Then I continue to the next page
 
 Scenario: Giving another phone number will allow the user to continue
   Given I start the interview
-  When I click the option with the text "I accept"
+  When I tap the option with the text "I accept"
   Then I continue to the next page
   Then I type "201 555-0123" in the "Other phone number" field
   Then I continue to the next page
 
 Scenario: Giving an email will allow the user to continue
   Given I start the interview
-  When I click the option with the text "I accept"
+  When I tap the option with the text "I accept"
   Then I continue to the next page
   Then I type "user@example.com" in the "Email address" field
   Then I continue to the next page
 
 Scenario: Giving other contact info will allow the user to continue
   Given I start the interview
-  When I click the option with the text "I accept"
+  When I tap the option with the text "I accept"
   Then I continue to the next page
   Then I type "Semaphore" in the "Other ways to reach you" field
   Then I continue to the next page

--- a/tests/features/user_court_contact_info.feature
+++ b/tests/features/user_court_contact_info.feature
@@ -14,48 +14,53 @@ Tests:
 Scenario: User contact info page should exist
   Given I start the interview
   When I tap the option with the text "I accept"
-  Then I continue to the next page
+  Then I tap the button "Next"
   Then the question id should be "your contact information"
 
 Scenario: Can't continue if gave no information
   Given I start the interview
   When I tap the option with the text "I accept"
-  Then I continue to the next page
+  Then I tap the button "Next"
   When I do nothing
   Then I can't continue
   
 Scenario: Get invalidation message if gave no information
   Given I start the interview
   When I tap the option with the text "I accept"
-  Then I continue to the next page
+  Then I tap the button "Next"
   When I do nothing
+  Then I tap the button "Next"
   Then I can't continue
   Then I will be told an answer is invalid
 
 Scenario: Giving a mobile number will allow the user to continue
   Given I start the interview
   When I tap the option with the text "I accept"
-  Then I continue to the next page
+  Then I tap the button "Next"
   Then I type "201 555-0123" in the "Mobile number" field
-  Then I continue to the next page
+  Then I tap the button "Next"
+  Then I arrive at the next page
 
 Scenario: Giving another phone number will allow the user to continue
   Given I start the interview
   When I tap the option with the text "I accept"
-  Then I continue to the next page
+  Then I tap the button "Next"
   Then I type "201 555-0123" in the "Other phone number" field
-  Then I continue to the next page
+  Then I tap the button "Next"
+  Then I arrive at the next page
 
 Scenario: Giving an email will allow the user to continue
   Given I start the interview
   When I tap the option with the text "I accept"
-  Then I continue to the next page
+  Then I tap the button "Next"
   Then I type "user@example.com" in the "Email address" field
-  Then I continue to the next page
+  Then I tap the button "Next"
+  Then I arrive at the next page
 
 Scenario: Giving other contact info will allow the user to continue
   Given I start the interview
   When I tap the option with the text "I accept"
-  Then I continue to the next page
+  Then I tap the button "Next"
   Then I type "Semaphore" in the "Other ways to reach you" field
-  Then I continue to the next page
+  Then I tap the button "Next"
+  Then I arrive at the next page

--- a/tests/features/user_roles_and_court.feature
+++ b/tests/features/user_roles_and_court.feature
@@ -8,24 +8,24 @@ Tests:
 
 Scenario: In-state defendant picks a court
   Given I start the interview
-  When I click the option with the text "I accept"
+  When I tap the option with the text "I accept"
   Then I continue to the next page
   Then I type "201 555-0123" in the "Mobile number" field
   Then I continue to the next page
   Then I type "Ulli" in the "First Name" field
   Then I type "User" in the "Last Name" field
   Then I continue to the next page
-  Then I click the button "No"
+  Then I tap the button "No"
   Then I type "112 Southampton St" in the "Street address" field
   Then I type "1" in the "Unit" field
   Then I type "Boston" in the "City" field
   Then I select the "Massachusetts" option from the "State" choices
   Then I type "02118" in the "Zip" field
   Then I continue to the next page
-  Then I click the "Responding to a case" option
+  Then I tap the "Responding to a case" option
   Then I continue to the next page
-  Then I click the button "Yes"
-  Then I click the option with the text "Business or organization"
+  Then I tap the button "Yes"
+  Then I tap the option with the text "Business or organization"
   Then I type "Plaintiff LLC" in the "Name of organization or business" field
   Then I continue to the next page
   Then the question id should be "choose a court (courts matching provided address were found)"
@@ -33,24 +33,24 @@ Scenario: In-state defendant picks a court
 
 Scenario: In-state plaintiff picks a court
   Given I start the interview
-  When I click the option with the text "I accept"
+  When I tap the option with the text "I accept"
   Then I continue to the next page
   Then I type "201 555-0123" in the "Mobile number" field
   Then I continue to the next page
   Then I type "Ulli" in the "First Name" field
   Then I type "User" in the "Last Name" field
   Then I continue to the next page
-  Then I click the button "No"
+  Then I tap the button "No"
   Then I type "112 Southampton St" in the "Street address" field
   Then I type "1" in the "Unit" field
   Then I type "Boston" in the "City" field
   Then I select the "Massachusetts" option from the "State" choices
   Then I type "02118" in the "Zip" field
   Then I continue to the next page
-  Then I click the "Starting a new case" option
+  Then I tap the "Starting a new case" option
   Then I continue to the next page
-  Then I click the button "Yes"
-  Then I click the option with the text "Business or organization"
+  Then I tap the button "Yes"
+  Then I tap the option with the text "Business or organization"
   Then I type "Defendant LLC" in the "Name of organization or business" field
   Then I continue to the next page
   Then the question id should be "choose a court (courts matching provided address were found)"
@@ -58,23 +58,23 @@ Scenario: In-state plaintiff picks a court
 
 Scenario: Out of state defendant picks a court
   Given I start the interview
-  When I click the option with the text "I accept"
+  When I tap the option with the text "I accept"
   Then I continue to the next page
   Then I type "201 555-0123" in the "Mobile number" field
   Then I continue to the next page
   Then I type "Ulli" in the "First Name" field
   Then I type "User" in the "Last Name" field
   Then I continue to the next page
-  Then I click the button "No"
+  Then I tap the button "No"
   Then I type "1600 Pennsylvania Avenue" in the "Street address" field
   Then I type "Washington" in the "City" field
   Then I select the "District of Columbia" option from the "State" choices
   Then I type "20500" in the "Zip" field
   Then I continue to the next page
-  Then I click the "Responding to a case" option
+  Then I tap the "Responding to a case" option
   Then I continue to the next page
-  Then I click the button "Yes"
-  Then I click the option with the text "Business or organization"
+  Then I tap the button "Yes"
+  Then I tap the option with the text "Business or organization"
   Then I type "Plaintiff LLC" in the "Name of organization or business" field
   Then I continue to the next page
   Then the question id should be "choose a court (no matching courts found)"
@@ -82,23 +82,23 @@ Scenario: Out of state defendant picks a court
 
 Scenario: Out of state plaintiff picks a court
   Given I start the interview
-  When I click the option with the text "I accept"
+  When I tap the option with the text "I accept"
   Then I continue to the next page
   Then I type "201 555-0123" in the "Mobile number" field
   Then I continue to the next page
   Then I type "Ulli" in the "First Name" field
   Then I type "User" in the "Last Name" field
   Then I continue to the next page
-  Then I click the button "No"
+  Then I tap the button "No"
   Then I type "1600 Pennsylvania Avenue" in the "Street address" field
   Then I type "Washington" in the "City" field
   Then I select the "District of Columbia" option from the "State" choices
   Then I type "20500" in the "Zip" field
   Then I continue to the next page
-  Then I click the "Starting a new case" option
+  Then I tap the "Starting a new case" option
   Then I continue to the next page
-  Then I click the button "Yes"
-  Then I click the option with the text "Business or organization"
+  Then I tap the button "Yes"
+  Then I tap the option with the text "Business or organization"
   Then I type "Defendant LLC" in the "Name of organization or business" field
   Then I continue to the next page
   Then the question id should be "choose a court (no matching courts found)"

--- a/tests/features/user_roles_and_court.feature
+++ b/tests/features/user_roles_and_court.feature
@@ -9,97 +9,97 @@ Tests:
 Scenario: In-state defendant picks a court
   Given I start the interview
   When I tap the option with the text "I accept"
-  Then I continue to the next page
+  Then I tap the button "Next"
   Then I type "201 555-0123" in the "Mobile number" field
-  Then I continue to the next page
+  Then I tap the button "Next"
   Then I type "Ulli" in the "First Name" field
   Then I type "User" in the "Last Name" field
-  Then I continue to the next page
+  Then I tap the button "Next"
   Then I tap the button "No"
   Then I type "112 Southampton St" in the "Street address" field
   Then I type "1" in the "Unit" field
   Then I type "Boston" in the "City" field
   Then I select the "Massachusetts" option from the "State" choices
   Then I type "02118" in the "Zip" field
-  Then I continue to the next page
+  Then I tap the button "Next"
   Then I tap the "Responding to a case" option
-  Then I continue to the next page
+  Then I tap the button "Next"
   Then I tap the button "Yes"
   Then I tap the option with the text "Business or organization"
   Then I type "Plaintiff LLC" in the "Name of organization or business" field
-  Then I continue to the next page
+  Then I tap the button "Next"
   Then the question id should be "choose a court (courts matching provided address were found)"
   Then I should see the phrase "What court is your case in?"
 
 Scenario: In-state plaintiff picks a court
   Given I start the interview
   When I tap the option with the text "I accept"
-  Then I continue to the next page
+  Then I tap the button "Next"
   Then I type "201 555-0123" in the "Mobile number" field
-  Then I continue to the next page
+  Then I tap the button "Next"
   Then I type "Ulli" in the "First Name" field
   Then I type "User" in the "Last Name" field
-  Then I continue to the next page
+  Then I tap the button "Next"
   Then I tap the button "No"
   Then I type "112 Southampton St" in the "Street address" field
   Then I type "1" in the "Unit" field
   Then I type "Boston" in the "City" field
   Then I select the "Massachusetts" option from the "State" choices
   Then I type "02118" in the "Zip" field
-  Then I continue to the next page
+  Then I tap the button "Next"
   Then I tap the "Starting a new case" option
-  Then I continue to the next page
+  Then I tap the button "Next"
   Then I tap the button "Yes"
   Then I tap the option with the text "Business or organization"
   Then I type "Defendant LLC" in the "Name of organization or business" field
-  Then I continue to the next page
+  Then I tap the button "Next"
   Then the question id should be "choose a court (courts matching provided address were found)"
   Then I should see the phrase "What court do you want to file in?"
 
 Scenario: Out of state defendant picks a court
   Given I start the interview
   When I tap the option with the text "I accept"
-  Then I continue to the next page
+  Then I tap the button "Next"
   Then I type "201 555-0123" in the "Mobile number" field
-  Then I continue to the next page
+  Then I tap the button "Next"
   Then I type "Ulli" in the "First Name" field
   Then I type "User" in the "Last Name" field
-  Then I continue to the next page
+  Then I tap the button "Next"
   Then I tap the button "No"
   Then I type "1600 Pennsylvania Avenue" in the "Street address" field
   Then I type "Washington" in the "City" field
   Then I select the "District of Columbia" option from the "State" choices
   Then I type "20500" in the "Zip" field
-  Then I continue to the next page
+  Then I tap the button "Next"
   Then I tap the "Responding to a case" option
-  Then I continue to the next page
+  Then I tap the button "Next"
   Then I tap the button "Yes"
   Then I tap the option with the text "Business or organization"
   Then I type "Plaintiff LLC" in the "Name of organization or business" field
-  Then I continue to the next page
+  Then I tap the button "Next"
   Then the question id should be "choose a court (no matching courts found)"
   Then I should see the phrase "What court is your case in?"
 
 Scenario: Out of state plaintiff picks a court
   Given I start the interview
   When I tap the option with the text "I accept"
-  Then I continue to the next page
+  Then I tap the button "Next"
   Then I type "201 555-0123" in the "Mobile number" field
-  Then I continue to the next page
+  Then I tap the button "Next"
   Then I type "Ulli" in the "First Name" field
   Then I type "User" in the "Last Name" field
-  Then I continue to the next page
+  Then I tap the button "Next"
   Then I tap the button "No"
   Then I type "1600 Pennsylvania Avenue" in the "Street address" field
   Then I type "Washington" in the "City" field
   Then I select the "District of Columbia" option from the "State" choices
   Then I type "20500" in the "Zip" field
-  Then I continue to the next page
+  Then I tap the button "Next"
   Then I tap the "Starting a new case" option
-  Then I continue to the next page
+  Then I tap the button "Next"
   Then I tap the button "Yes"
   Then I tap the option with the text "Business or organization"
   Then I type "Defendant LLC" in the "Name of organization or business" field
-  Then I continue to the next page
+  Then I tap the button "Next"
   Then the question id should be "choose a court (no matching courts found)"
   Then I should see the phrase "What court do you want to file in?"

--- a/tests/features/user_roles_and_court.feature
+++ b/tests/features/user_roles_and_court.feature
@@ -8,7 +8,7 @@ Tests:
 
 Scenario: In-state defendant picks a court
   Given I start the interview
-  Then I check the "I accept" checkbox
+  When I click the option with the text "I accept"
   Then I continue to the next page
   Then I type "201 555-0123" in the "Mobile number" field
   Then I continue to the next page
@@ -22,10 +22,10 @@ Scenario: In-state defendant picks a court
   Then I select the "Massachusetts" option from the "State" choices
   Then I type "02118" in the "Zip" field
   Then I continue to the next page
-  Then I pick the "Responding to a case" option
+  Then I click the "Responding to a case" option
   Then I continue to the next page
   Then I click the button "Yes"
-  Then I check the "Business or organization" checkbox
+  Then I click the option with the text "Business or organization"
   Then I type "Plaintiff LLC" in the "Name of organization or business" field
   Then I continue to the next page
   Then the question id should be "choose a court (courts matching provided address were found)"
@@ -33,7 +33,7 @@ Scenario: In-state defendant picks a court
 
 Scenario: In-state plaintiff picks a court
   Given I start the interview
-  Then I check the "I accept" checkbox
+  When I click the option with the text "I accept"
   Then I continue to the next page
   Then I type "201 555-0123" in the "Mobile number" field
   Then I continue to the next page
@@ -47,10 +47,10 @@ Scenario: In-state plaintiff picks a court
   Then I select the "Massachusetts" option from the "State" choices
   Then I type "02118" in the "Zip" field
   Then I continue to the next page
-  Then I pick the "Starting a new case" option
+  Then I click the "Starting a new case" option
   Then I continue to the next page
   Then I click the button "Yes"
-  Then I check the "Business or organization" checkbox
+  Then I click the option with the text "Business or organization"
   Then I type "Defendant LLC" in the "Name of organization or business" field
   Then I continue to the next page
   Then the question id should be "choose a court (courts matching provided address were found)"
@@ -58,7 +58,7 @@ Scenario: In-state plaintiff picks a court
 
 Scenario: Out of state defendant picks a court
   Given I start the interview
-  Then I check the "I accept" checkbox
+  When I click the option with the text "I accept"
   Then I continue to the next page
   Then I type "201 555-0123" in the "Mobile number" field
   Then I continue to the next page
@@ -71,10 +71,10 @@ Scenario: Out of state defendant picks a court
   Then I select the "District of Columbia" option from the "State" choices
   Then I type "20500" in the "Zip" field
   Then I continue to the next page
-  Then I pick the "Responding to a case" option
+  Then I click the "Responding to a case" option
   Then I continue to the next page
   Then I click the button "Yes"
-  Then I check the "Business or organization" checkbox
+  Then I click the option with the text "Business or organization"
   Then I type "Plaintiff LLC" in the "Name of organization or business" field
   Then I continue to the next page
   Then the question id should be "choose a court (no matching courts found)"
@@ -82,7 +82,7 @@ Scenario: Out of state defendant picks a court
 
 Scenario: Out of state plaintiff picks a court
   Given I start the interview
-  Then I check the "I accept" checkbox
+  When I click the option with the text "I accept"
   Then I continue to the next page
   Then I type "201 555-0123" in the "Mobile number" field
   Then I continue to the next page
@@ -95,10 +95,10 @@ Scenario: Out of state plaintiff picks a court
   Then I select the "District of Columbia" option from the "State" choices
   Then I type "20500" in the "Zip" field
   Then I continue to the next page
-  Then I pick the "Starting a new case" option
+  Then I click the "Starting a new case" option
   Then I continue to the next page
   Then I click the button "Yes"
-  Then I check the "Business or organization" checkbox
+  Then I click the option with the text "Business or organization"
   Then I type "Defendant LLC" in the "Name of organization or business" field
   Then I continue to the next page
   Then the question id should be "choose a court (no matching courts found)"

--- a/tests/interview-constants.js
+++ b/tests/interview-constants.js
@@ -5,7 +5,6 @@ const putils = require('./puppeteer-utils');
 let filename = 'basic_questions_tests';  // Easier to edit
 const INTERVIEW_URL_START = process.env.INTERVIEW_URL || `${putils.BASE_INTERVIEW_URL}%3A`;
 const INTERVIEW_URL = process.env.INTERVIEW_URL || `${INTERVIEW_URL_START}${filename}.yml`;
-console.log('INTERVIEW_URL:', INTERVIEW_URL);
 
 
 module.exports = {

--- a/tests/interview-constants.js
+++ b/tests/interview-constants.js
@@ -3,9 +3,12 @@ const putils = require('./puppeteer-utils');
 // Each repo has its own interview that it's testing
 // We'll deal with multiple urls when it becomes an issue
 let filename = 'basic_questions_tests';  // Easier to edit
-const INTERVIEW_URL = process.env.INTERVIEW_URL || `${putils.BASE_INTERVIEW_URL}%3A${filename}.yml`;
+const INTERVIEW_URL_START = process.env.INTERVIEW_URL || `${putils.BASE_INTERVIEW_URL}%3A`;
+const INTERVIEW_URL = process.env.INTERVIEW_URL || `${INTERVIEW_URL_START}${filename}.yml`;
+console.log('INTERVIEW_URL:', INTERVIEW_URL);
 
 
 module.exports = {
   INTERVIEW_URL,
+  INTERVIEW_URL_START
 };


### PR DESCRIPTION
This does a bit much, but they mostly seemed intertwined at the time.

1. Separates concerns for the test developer between buttons, navigation detection, etc, improving consistency. That is, you have to press the 'Next' button to navigate and then you can, separately, test that you got to a new page. It does decrease flexibility in some ways and means a bit more boilerplate sometimes.
1. Speeds up some things by detecting actual da error pages and such.
1. Creates `scope.afterStep` (there is none in puppeteer cucumber). It was needed for a few reasons:
   1. It detects actual da error pages, speeding up test errors. I may have brain freeze, but it seemed to me like something that should be done after every step.
   1. Resets navigation detection, which does need to be done after every step, so that page navigation can be detected correctly
   1. Can handle other end-of-step stuff, like waiting extra after a page is loaded. That's something that would be at the end anyway. Which reminds me - I'll try to add that in for after page navigation. Hmm, that may be tricky considering we also need to wait for `show if`.
   1. Basically, I didn't want to pile up a bunch of stacked up functionality at the end of each step, so I combined it into one call. Interested to hear what thoughts people have on it.
1. Remembered why we had the flexibility for the label, button, link, etc. text all over the place - all those funny characters. I mostly switched back to that methodology and added a note about it. Didn't intend for that to be with this PR, but life is chaos.