### PR TITLE
Add rudimentary court list test. Brainstorm more precise test...

### DIFF
--- a/docassemble/MAVirtualCourt/data/questions/basic_questions_tests.yml
+++ b/docassemble/MAVirtualCourt/data/questions/basic_questions_tests.yml
@@ -21,7 +21,7 @@ code: |
   allowed_courts = [
     'District Court',
     'Boston Municipal Court',
-    'Superior Court',
+    #'Superior Court',
     'Probate and Family Court',
     'Juvenile Court',
     'Housing Court',

--- a/tests/features/court_list.feature
+++ b/tests/features/court_list.feature
@@ -1,0 +1,43 @@
+Feature: Only allowed courts are listed
+
+- [x] Exclusion of Superior Court
+
+Test interview will have to be modified to allow this
+- [ ] Exclusion of District Court
+- [ ] Exclusion of Boston Municipal Court
+- [ ] Exclusion of Land Court
+- [ ] Exclusion of Juvenile Court
+- [ ] Exclusion of Probate and Family Court
+- [ ] Exclusion of Housing Court
+- [ ] Inclusion of all courts
+
+Scenario: All except Superior Court
+  Given I start the interview
+  When I tap the option with the text "I accept"
+  Then I tap the button "Next"
+  Then I type "201 555-0123" in the "Mobile number" field
+  Then I tap the button "Next"
+  Then I type "Ulli" in the "First Name" field
+  Then I type "User" in the "Last Name" field
+  Then I tap the button "Next"
+  Then I tap the button "No"
+  Then I type "112 Southampton St" in the "Street address" field
+  Then I type "1" in the "Unit" field
+  Then I type "Boston" in the "City" field
+  Then I select the "Massachusetts" option from the "State" choices
+  Then I type "02118" in the "Zip" field
+  Then I tap the button "Next"
+  Then I tap the "Starting a new case" option
+  Then I tap the button "Next"
+  Then I tap the button "Yes"
+  Then I tap the option with the text "Business or organization"
+  Then I type "Defendant LLC" in the "Name of organization or business" field
+  Then I tap the button "Next"
+  Then the question id should be "choose a court (courts matching provided address were found)"
+  Then I should not see the phrase "Superior Court"
+  Then I should see the phrase "District Court"
+  Then I should see the phrase "Boston Municipal Court"
+  Then I should see the phrase "Land Court"
+  Then I should see the phrase "Juvenile Court"
+  Then I should see the phrase "Probate and Family Court"
+  Then I should see the phrase "Housing Court"

--- a/tests/features/court_list.feature
+++ b/tests/features/court_list.feature
@@ -11,7 +11,7 @@ Test interview will have to be modified to allow this
 - [ ] Exclusion of Housing Court
 - [ ] Inclusion of all courts
 
-Scenario: All except Superior Court
+Scenario: Show all courts except Superior Court
   Given I start the interview
   When I tap the option with the text "I accept"
   Then I tap the button "Next"

--- a/tests/features/support/steps.js
+++ b/tests/features/support/steps.js
@@ -229,7 +229,8 @@ Then(prohibited_choice_words_regex, async (prohibited, specifier) => {
   *
   * @param prohibited {string} String, possibly containing commas and ', or' to
   *    denote multiple phrases, that should not appear in the options.
-  * @param specifier {string} Text that is in the label of the <select>
+  * @param specifier {string} Optional. Either an ordinal up to 'tenth' or text that
+  *    is in the label of the <select>
   */
   // Make sure ajax is finished getting the items in the <select>
   await scope.page.waitForSelector('option');

--- a/tests/features/support/steps.js
+++ b/tests/features/support/steps.js
@@ -105,6 +105,14 @@ Then('I should see the phrase {string}', async (phrase) => {
   await scope.afterStep(scope);
 });
 
+Then('I should not see the phrase {string}', async (phrase) => {
+  /* In Chrome, this `innerText` gets only visible text */
+  const bodyText = await scope.page.$eval('body', elem => elem.innerText);
+  expect(bodyText).not.to.contain(phrase);
+
+  await scope.afterStep(scope);
+});
+
 Then('I should see the link {string}', async (linkText) => {
   let [link] = await scope.page.$x(`//a[contains(text(), "${linkText}")]`);
   expect(link).to.exist;
@@ -204,6 +212,59 @@ Then(/the link "([^"]+)" should open in (a new window|the same window)/, async (
 
   expect( hasCorrectWindowTarget ).to.be.true;
   
+  await scope.afterStep(scope);
+});
+
+// FEATURE IN DEVELOPMENT. A FOOL'S ERRAND
+let number_map = {first: 0, second: 1, third: 2, fourth: 3, fifth: 4, sixth: 5, seventh: 6, eighth: 7, ninth: 8, tenth: 9, };
+let specified = '?"?(first|second|third|fourth|fifth|sixth|seventh|eighth|ninth|tenth|"[^"]+)?"?';
+let prohibited_choice_words = `I should not see the options? "([^"]+)" ?(?:in the ${specified} choice list)?`;
+let prohibited_choice_words_regex = new RegExp(prohibited_choice_words);
+Then(prohibited_choice_words_regex, async (prohibited, specifier) => {
+  /* In development.
+  *
+  * Checks that `prohibited` does not appear in the text of the
+  *    the list of options in the <select> with the label "containing" the `label text`.
+  *    Only checks the first <select>.
+  *
+  * @param prohibited {string} String, possibly containing commas and ', or' to
+  *    denote multiple phrases, that should not appear in the options.
+  * @param specifier {string} Text that is in the label of the <select>
+  */
+  // Make sure ajax is finished getting the items in the <select>
+  await scope.page.waitForSelector('option');
+
+  let options = await scope.page.$$(`option`);
+  if ( specifier ) {
+    // If they want to check a specific set of options
+
+    // The <label> will have the `id` for the <select> we're looking for
+    let [label] = await scope.page.$x(`//label[contains(text(), "${specifier}")]`);
+    if ( !label ) {
+      [label] = await scope.page.$x(`//label//a[contains(text(), "${specifier}")]`);
+    }
+
+    let select_id = await scope.page.evaluate(( label ) => {
+      return label.getAttribute('for');
+    }, label);
+
+    options = await scope.page.$$(`*[id*='${ select_id }'] option`);
+  }
+
+  let phrases = prohibited.split(', ');
+  // Take 'or' off of the last item if it's there.
+  let last_phrase = phrases.pop();
+  last_phrase = last_phrase.replace(/^or /, '');
+  phrases.push( last_phrase );
+
+  for (let option in options) {
+    let prop_handle = await option.getProperty( 'textContent' );
+    let option_text = await prop_handle.jsonValue();
+    for (let phrase in phrases) {
+      expect( option_text ).not.to.contain( phrase );
+    }
+  }
+
   await scope.afterStep(scope);
 });
 
@@ -313,6 +374,7 @@ When(/I tap the option with the text "([^"]+)"/, async (label_text) => {
   await scope.afterStep(scope, {waitForShowIf: true});
 });
 
+// 'I choose {string}'?
 When('I tap the {string} option', async (label_text) => {
   /* taps the first label with the exact `label_text`.
   *    Very limited. Anything more is a future feature.


### PR DESCRIPTION
though I think maybe the best next path is to recreate the da tests
that we think we'll be using. They're the most familar with the da
DOM structure. Always have to try the hard way first!

The brainstorm is a bit of a mess and chaotic. I can leave that in another branch somewhere, but I'm concerned about losing track of it. Thoughts?